### PR TITLE
Improve dashboard and plan layout spacing

### DIFF
--- a/src/components/PlanCard.tsx
+++ b/src/components/PlanCard.tsx
@@ -15,24 +15,32 @@ export function PlanCard({
   onDuplicate: () => void;
 }) {
   return (
-    <Card className="flex flex-col gap-4">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h3 className="text-lg font-semibold">{plan.meta.name}</h3>
-          <p className="text-sm text-slate-500">
-            {plan.meta.code} • v{plan.meta.version} • Status: {plan.status}
-          </p>
+    <Card className="flex flex-col gap-5">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-2">
+          <h3 className="text-xl font-semibold text-slate-900">{plan.meta.name}</h3>
+          <div className="flex flex-wrap items-center gap-2 text-xs font-medium text-slate-500">
+            <span className="rounded-full bg-indigo-50 px-2.5 py-1 text-xs font-semibold text-indigo-600">
+              v{plan.meta.version}
+            </span>
+            <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs text-slate-600">
+              {plan.status}
+            </span>
+            <span className="text-slate-400">{plan.meta.code}</span>
+          </div>
         </div>
-        <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
+        <span className="inline-flex items-center rounded-full bg-slate-50 px-3 py-1 text-xs font-medium text-slate-500">
           Updated {formatDate(plan.lastModified)}
         </span>
       </div>
-      <div className="flex flex-wrap gap-2">
-        <Button onClick={onOpen}>Open</Button>
-        <Button variant="secondary" onClick={onReview}>
+      <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+        <Button onClick={onOpen} className="w-full sm:flex-1">
+          Open
+        </Button>
+        <Button variant="secondary" onClick={onReview} className="w-full sm:flex-1">
           Review
         </Button>
-        <Button variant="ghost" onClick={onDuplicate}>
+        <Button variant="ghost" onClick={onDuplicate} className="w-full sm:w-auto">
           Duplicate
         </Button>
       </div>

--- a/src/components/PlanList.tsx
+++ b/src/components/PlanList.tsx
@@ -17,7 +17,7 @@ export function PlanList({
   }
 
   return (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+    <div className="grid grid-cols-1 gap-5 sm:gap-6 md:grid-cols-2">
       {plans.map((plan) => (
         <PlanCard
           key={plan.id}

--- a/src/components/PlanTitleBar.tsx
+++ b/src/components/PlanTitleBar.tsx
@@ -58,37 +58,52 @@ export function PlanTitleBar({
   const showReject = plan.status === 'Submitted' && canApprove(user);
   const showRevert = plan.status !== 'Draft' && plan.status !== 'Approved';
 
+  const nameId = `plan-name-${plan.id}`;
+  const codeId = `plan-code-${plan.id}`;
+
   return (
-    <div className="flex flex-col gap-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <div className="flex flex-col gap-2">
-          <div className="flex flex-wrap items-center gap-3">
-            <form className="flex flex-wrap items-center gap-3" onSubmit={(event) => event.preventDefault()}>
+    <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
+      <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex w-full flex-col gap-4 lg:max-w-xl">
+          <form
+            className="grid w-full gap-4 sm:grid-cols-3 sm:items-end"
+            onSubmit={(event) => event.preventDefault()}
+          >
+            <div className="flex flex-col gap-1 sm:col-span-2">
+              <label htmlFor={nameId} className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                Plan name
+              </label>
               <Input
                 {...form.register('name')}
+                id={nameId}
                 onBlur={() => submitMeta()}
                 disabled={editingDisabled}
-                className="w-64"
-                aria-label="Plan name"
+                className="w-full"
               />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label htmlFor={codeId} className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                Plan code
+              </label>
               <Input
                 {...form.register('code')}
+                id={codeId}
                 onBlur={() => submitMeta()}
                 disabled={editingDisabled}
-                className="w-40"
-                aria-label="Plan code"
+                className="w-full"
               />
-            </form>
+            </div>
+          </form>
+          <div className="flex flex-wrap items-center gap-2 text-xs font-medium text-slate-500">
             <span className="rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-600">
               v{plan.meta.version}
             </span>
-            <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
-              {plan.status}
-            </span>
+            <span className="rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-600">{plan.status}</span>
+            <span className="text-slate-400">Last modified {new Date(plan.lastModified).toLocaleString()}</span>
           </div>
-          <p className="text-xs text-slate-500">Autosaves instantly. Last modified {new Date(plan.lastModified).toLocaleString()}</p>
+          <p className="text-xs text-slate-500">Autosaves instantly after each change.</p>
         </div>
-        <div className="flex flex-wrap gap-2">
+        <div className="flex w-full flex-col gap-2 sm:flex-row sm:flex-wrap sm:justify-end lg:w-auto">
           <Button variant="ghost" onClick={onDuplicate}>
             Duplicate
           </Button>
@@ -114,6 +129,6 @@ export function PlanTitleBar({
           ) : null}
         </div>
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/components/SummarySidebar.tsx
+++ b/src/components/SummarySidebar.tsx
@@ -6,35 +6,44 @@ export function SummarySidebar({ plan }: { plan: Plan }) {
   const totals = calculatePlanTotals(plan);
 
   return (
-    <aside className="flex flex-col gap-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-      <div>
-        <h3 className="text-sm font-semibold text-slate-700">Plan Summary</h3>
-        <p className="text-xs text-slate-500">Snapshot of spend and mix.</p>
+    <aside className="flex flex-col gap-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold text-slate-900">Plan Summary</h2>
+        <p className="text-sm text-slate-500">Snapshot of spend, pace, and channel mix.</p>
       </div>
-      <div className="space-y-2 text-sm">
-        <div className="flex items-center justify-between">
-          <span>Total Budget</span>
-          <span className="font-semibold">{currencyFormatter.format(totals.totalBudget)}</span>
+      <dl className="space-y-3 text-sm">
+        <div className="flex items-baseline justify-between gap-4">
+          <dt className="text-slate-500">Total Budget</dt>
+          <dd className="text-right font-semibold text-slate-900">
+            {currencyFormatter.format(totals.totalBudget)}
+          </dd>
         </div>
-        <div className="flex items-center justify-between">
-          <span>Impressions</span>
-          <span className="font-semibold">{currencyFormatter.format(totals.totalImpressions).replace('$', '')}</span>
+        <div className="flex items-baseline justify-between gap-4">
+          <dt className="text-slate-500">Impressions</dt>
+          <dd className="text-right font-semibold text-slate-900">
+            {currencyFormatter.format(totals.totalImpressions).replace('$', '')}
+          </dd>
         </div>
-        <div className="flex items-center justify-between">
-          <span>Blended CPM</span>
-          <span className="font-semibold">{currencyFormatter.format(totals.cpm)}</span>
+        <div className="flex items-baseline justify-between gap-4">
+          <dt className="text-slate-500">Blended CPM</dt>
+          <dd className="text-right font-semibold text-slate-900">
+            {currencyFormatter.format(totals.cpm)}
+          </dd>
         </div>
-      </div>
-      <div>
-        <h4 className="text-xs uppercase tracking-wide text-slate-500">Channel Mix</h4>
-        <ul className="mt-2 space-y-1 text-sm">
+      </dl>
+      <div className="space-y-3">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Channel Mix</h3>
+        <ul className="space-y-2 text-sm">
           {totals.channels.map((channel) => {
             const share = totals.totalBudget === 0 ? 0 : channel.budget / totals.totalBudget;
             return (
-              <li key={channel.channel} className="flex items-center justify-between">
-                <span>{channel.channel}</span>
-                <span>
-                  {currencyFormatter.format(channel.budget)} • {percentFormatter.format(share)}
+              <li key={channel.channel} className="flex items-center justify-between gap-4">
+                <span className="text-slate-600">{channel.channel}</span>
+                <span className="text-right font-medium text-slate-900">
+                  {currencyFormatter.format(channel.budget)}
+                  <span className="ml-2 text-xs font-medium text-slate-500">
+                    {percentFormatter.format(share)}
+                  </span>
                 </span>
               </li>
             );

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -21,25 +21,33 @@ export function DashboardPage() {
   };
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-2xl font-semibold text-slate-900">Plans</h2>
-          <p className="text-sm text-slate-500">Manage media plans, versions, and approvals.</p>
-        </div>
-        <Button onClick={handleCreate} disabled={createPlan.isPending}>
-          New Plan
-        </Button>
-      </div>
-      {isLoading ? <p className="text-sm text-slate-500">Loading plans...</p> : null}
-      {!isLoading ? (
-        <PlanList
-          plans={plans}
-          onOpen={(id) => navigate(`/plan/${id}`)}
-          onReview={(id) => navigate(`/plan/${id}/review`)}
-          onDuplicate={handleDuplicate}
-        />
-      ) : null}
-    </div>
+    <main className="container mx-auto max-w-6xl px-4 py-6 lg:py-8">
+      <section className="space-y-6">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div className="space-y-1">
+            <h1 className="text-3xl font-semibold text-slate-900">Plans</h1>
+            <p className="text-sm text-slate-500 sm:max-w-xl">
+              Manage media plans, versions, and approvals from one place.
+            </p>
+          </div>
+          <Button
+            onClick={handleCreate}
+            disabled={createPlan.isPending}
+            className="self-start sm:self-auto"
+          >
+            New Plan
+          </Button>
+        </header>
+        {isLoading ? <p className="text-sm text-slate-500">Loading plans...</p> : null}
+        {!isLoading ? (
+          <PlanList
+            plans={plans}
+            onOpen={(id) => navigate(`/plan/${id}`)}
+            onReview={(id) => navigate(`/plan/${id}/review`)}
+            onDuplicate={handleDuplicate}
+          />
+        ) : null}
+      </section>
+    </main>
   );
 }

--- a/src/pages/MediaPlanningPage.tsx
+++ b/src/pages/MediaPlanningPage.tsx
@@ -94,51 +94,62 @@ export function MediaPlanningPage() {
   };
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-semibold text-slate-900">{pageTitle}</h2>
-        <Button variant="secondary" onClick={() => setExportOpen(true)}>
-          Export Block Plan
-        </Button>
-      </div>
-      <PlanTitleBar
-        plan={plan}
-        editingDisabled={Boolean(editingDisabled)}
-        onSubmit={handleSubmit}
-        onApprove={handleApprove}
-        onReject={handleReject}
-        onRevert={handleRevert}
-        onDuplicate={handleDuplicate}
-      />
-      <GoalKPIBar plan={plan} />
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[2fr,1fr]">
-        <div className="space-y-4">
-          <ChannelTable plan={plan} readOnly={editingDisabled} />
-          <BudgetAllocator plan={plan} onBudgetChange={handleBudgetChange} readOnly={editingDisabled} />
-          <PacingWarnings plan={plan} />
-          <AuditDrawer events={plan.audit} />
+    <main className="container mx-auto max-w-7xl px-4 py-6 lg:py-8">
+      <div className="space-y-6">
+        <header className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-1">
+            <h1 className="text-3xl font-semibold text-slate-900">{pageTitle}</h1>
+            <p className="text-sm text-slate-500 sm:max-w-2xl">
+              Adjust channel budgets, track pacing, and share plans for approval.
+            </p>
+          </div>
+          <Button
+            variant="secondary"
+            onClick={() => setExportOpen(true)}
+            className="self-start lg:self-auto"
+          >
+            Export Block Plan
+          </Button>
+        </header>
+        <PlanTitleBar
+          plan={plan}
+          editingDisabled={Boolean(editingDisabled)}
+          onSubmit={handleSubmit}
+          onApprove={handleApprove}
+          onReject={handleReject}
+          onRevert={handleRevert}
+          onDuplicate={handleDuplicate}
+        />
+        <GoalKPIBar plan={plan} />
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+          <div className="space-y-6 lg:col-span-2">
+            <ChannelTable plan={plan} readOnly={editingDisabled} />
+            <BudgetAllocator plan={plan} onBudgetChange={handleBudgetChange} readOnly={editingDisabled} />
+            <PacingWarnings plan={plan} />
+            <AuditDrawer events={plan.audit} />
+          </div>
+          <SummarySidebar plan={plan} />
         </div>
-        <SummarySidebar plan={plan} />
+        <ExportDialog plan={plan} open={exportOpen} onClose={() => setExportOpen(false)} />
+        <ConfirmDialog
+          title="Reject Plan"
+          description="Provide feedback for the planner."
+          open={rejectOpen}
+          destructive
+          confirmText="Reject"
+          onCancel={() => setRejectOpen(false)}
+          onConfirm={confirmReject}
+          body={
+            <textarea
+              className="mt-2 w-full rounded-md border border-slate-300 p-3 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              rows={4}
+              value={rejectComment}
+              onChange={(event) => setRejectComment(event.target.value)}
+              placeholder="Share why the plan was rejected"
+            />
+          }
+        />
       </div>
-      <ExportDialog plan={plan} open={exportOpen} onClose={() => setExportOpen(false)} />
-      <ConfirmDialog
-        title="Reject Plan"
-        description="Provide feedback for the planner."
-        open={rejectOpen}
-        destructive
-        confirmText="Reject"
-        onCancel={() => setRejectOpen(false)}
-        onConfirm={confirmReject}
-        body={
-          <textarea
-            className="mt-2 w-full rounded-md border border-slate-300 p-2 text-sm"
-            rows={4}
-            value={rejectComment}
-            onChange={(event) => setRejectComment(event.target.value)}
-            placeholder="Share why the plan was rejected"
-          />
-        }
-      />
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
- wrap dashboard and media planning views in constrained containers with responsive headers
- refine plan cards, lists, and summary sidebar spacing for clearer hierarchy across breakpoints
- reorganize the plan title bar form and actions for improved accessibility and stacking on small screens

## Testing
- npm run build *(fails: [vite] Rollup failed to resolve import "react-router-dom" from src/app/providers.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68d6113f852c8321b0d10a757151e8e4