### PR TITLE
Add mock auth dev mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ npm install
 npm run dev
 ```
 
+### Authentication modes during development
+
+The app supports both the production Firebase authentication flow and a mock mode that bypasses sign-in entirely. Use the mock mode whenever you want to exercise the planning features locally without logging in:
+
+```bash
+npm run dev:mock
+```
+
+When you need to test the full authentication experience against Firebase (for example when running against emulators or a staging project), start the dev server with:
+
+```bash
+npm run dev:firebase
+```
+
+Both commands respect the rest of the environment configuration documented below.
+
 
 ## Local testing with Firebase emulators
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@typescript-eslint/parser": "^8.18.1",
         "@vitejs/plugin-react": "^5.0.0",
         "autoprefixer": "^10.4.21",
+        "cross-env": "^10.0.0",
         "eslint": "^9.33.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
@@ -549,6 +550,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.9",
@@ -3703,6 +3711,24 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:mock": "cross-env VITE_AUTH_MODE=mock vite",
+    "dev:firebase": "cross-env VITE_AUTH_MODE=firebase vite",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
@@ -37,6 +39,7 @@
     "@typescript-eslint/parser": "^8.18.1",
     "@vitejs/plugin-react": "^5.0.0",
     "autoprefixer": "^10.4.21",
+    "cross-env": "^10.0.0",
     "eslint": "^9.33.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",

--- a/src/app/env.ts
+++ b/src/app/env.ts
@@ -1,5 +1,13 @@
 export const ENV = {
   mode: import.meta.env.MODE,
+  auth:
+    import.meta.env.VITE_AUTH_MODE === 'firebase'
+      ? 'firebase'
+      : import.meta.env.VITE_AUTH_MODE === 'mock'
+        ? 'mock'
+        : import.meta.env.MODE === 'production'
+          ? 'firebase'
+          : 'mock',
   storage:
     import.meta.env.VITE_USE_LOCAL_ONLY === 'true' || import.meta.env.MODE !== 'production'
       ? 'local'
@@ -9,3 +17,4 @@ export const ENV = {
 } as const;
 
 export type StorageMode = typeof ENV.storage;
+export type AuthMode = typeof ENV.auth;

--- a/src/auth/AuthGate.tsx
+++ b/src/auth/AuthGate.tsx
@@ -1,10 +1,60 @@
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import { useUser } from './useUser';
 import { Select } from '@/ui/Select';
 import { Card } from '@/ui/Card';
+import { Button } from '@/ui/Button';
 
 export function AuthGate({ children }: { children: ReactNode }) {
-  const { user, setRole } = useUser();
+  const { user, setRole, status, mode, canEditRole, signIn, signOut } = useUser();
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSignIn = async () => {
+    try {
+      setError(null);
+      await signIn();
+    } catch (err) {
+      console.error(err);
+      setError('Sign-in failed. Please try again.');
+    }
+  };
+
+  const handleSignOut = async () => {
+    try {
+      setError(null);
+      await signOut();
+    } catch (err) {
+      console.error(err);
+      setError('Sign-out failed. Please try again.');
+    }
+  };
+
+  if (status === 'loading') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 text-slate-600">
+        <p className="text-sm">Checking your session…</p>
+      </div>
+    );
+  }
+
+  if (mode === 'firebase' && status === 'unauthenticated') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 px-4 text-slate-900">
+        <Card className="w-full max-w-md space-y-4 p-6">
+          <div className="space-y-2 text-center">
+            <h1 className="text-xl font-semibold">Sign in to Media Planner</h1>
+            <p className="text-sm text-slate-500">
+              Use your workspace credentials to continue. For local development without authentication, run
+              <code className="mx-1 rounded bg-slate-100 px-1.5 py-0.5 text-xs font-mono">npm run dev:mock</code>.
+            </p>
+          </div>
+          {error ? <p className="text-sm text-rose-600">{error}</p> : null}
+          <Button variant="primary" onClick={handleSignIn} className="w-full">
+            Continue with Google
+          </Button>
+        </Card>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-slate-50 text-slate-900">
@@ -12,19 +62,33 @@ export function AuthGate({ children }: { children: ReactNode }) {
         <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-6 py-4">
           <div>
             <h1 className="text-lg font-semibold">Media Planner</h1>
-            <p className="text-sm text-slate-500">Signed in as {user.name}</p>
+            <p className="text-sm text-slate-500">
+              Signed in as {user.name}
+              {user.email ? <span className="ml-1 text-xs">({user.email})</span> : null}
+            </p>
           </div>
-          <div className="flex items-center gap-2 text-sm">
-            <span className="text-slate-500">Role</span>
-            <Select value={user.role} onChange={(event) => setRole(event.target.value as typeof user.role)}>
-              <option value="Planner">Planner</option>
-              <option value="Manager">Manager</option>
-              <option value="Admin">Admin</option>
-            </Select>
-          </div>
+          {canEditRole && mode === 'mock' ? (
+            <div className="flex items-center gap-2 text-sm">
+              <span className="text-slate-500">Role</span>
+              <Select value={user.role} onChange={(event) => setRole(event.target.value as typeof user.role)}>
+                <option value="Planner">Planner</option>
+                <option value="Manager">Manager</option>
+                <option value="Admin">Admin</option>
+              </Select>
+            </div>
+          ) : (
+            <Button variant="ghost" onClick={handleSignOut} className="text-sm text-slate-500">
+              Sign out
+            </Button>
+          )}
         </div>
       </header>
       <main className="mx-auto max-w-6xl px-6 py-6">
+        {error && mode === 'firebase' && status === 'authenticated' ? (
+          <p className="mb-4 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-700">
+            {error}
+          </p>
+        ) : null}
         <Card>{children}</Card>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- add an auth mode switch that chooses between the existing mock user context and a Firebase-backed provider
- update the authentication gate to show a Firebase sign-in prompt with clear messaging about the mock dev mode
- document new dev scripts and wire up cross-env so local runs can opt into mock or Firebase auth flows

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d79aa2563c83219e91e0706eca8e98