### PR TITLE
Add channel scaffolding and block plan pulses

### DIFF
--- a/docs/components/channel-table.md
+++ b/docs/components/channel-table.md
@@ -1,0 +1,61 @@
+# Channel hierarchy implementation
+
+The media plan page renders channels with a two-tier hierarchy. Each channel row summarises the
+line items assigned to that channel, and expanding a row reveals all flightings with the
+channel-specific columns required by trading and reporting teams.
+
+## Column dictionary
+
+`src/components/ChannelTable.tsx` now builds each channel's flighting table from a shared
+`getColumnsForChannel(channel)` helper. The helper always emits the required columns—Vendor,
+placement detail, objective, units planned, cost, and fees—while delegating to channel-specific
+formatters for the placement and objective strings.
+
+To add a new channel type:
+
+1. Update `placementLabel`, `formatPlacementDetail`, `formatObjective`, or `formatUnits` with the
+   new channel's nuances so the base columns surface the correct contextual values.
+2. If the channel introduces a new extension payload, extend
+   `extensionKeyByChannel` in `src/lib/channelExtensions.ts` so both the table and details modal can
+   access the structured data.
+
+## Lazy flighting queries
+
+Channel expansion is powered by `useChannelFlightings(planId, channel)` from `src/api/plans.ts`.
+The hook reads the plan from the store on demand, filters the line items for the requested channel
+and caches the result for five minutes with React Query. The table only invokes the hook when a
+channel is expanded, keeping the default render path lightweight.
+
+## Flighting details modal
+
+`FlightDetailsModal` presents the full payload in grouped sections. The modal reads the same
+`extensionKeyByChannel` mapping to render channel-specific metadata, ensures currency and date
+formatting use the `en-AU` locale, and uses the shared `Modal` primitive to trap focus and restore
+it to the triggering disclosure button.
+
+## Extending the experience
+
+When adding support for a new channel type:
+
+- Extend the `getColumnsForChannel` helpers (`placementLabel`, `formatPlacementDetail`,
+  `formatObjective`, `formatUnits`) and the shared `extensionKeyByChannel` map as described above.
+- Add representative fixtures to `src/tests/ChannelTable.test.tsx` so the unique column rendering is
+  exercised in tests.
+- Consider updating the `plans` seed to include at least one line item for the new channel so
+  preview environments demonstrate the full hierarchy.
+
+## Budget share & channel creation
+
+Editable plans surface an **Add channel** action next to the table title. Triggering the dialog
+provisions a minimal flight, audience, vendor, creative, tracking payload, and channel-specific
+extension with placeholder values so planners can immediately start capturing details. Each summary
+row now reports the channel's share of total planned budget (the new *Budget %* column) to replace
+the retired summary sidebar.
+
+## Pulsed scheduling
+
+Flight rows expose an **Edit schedule** button that launches `FlightingScheduleDialog`. The dialog
+presents a week-by-week selector so planners can capture pulsing behaviour—weeks toggle between
+active and dark periods, and the dialog persists the selection to
+`flight.active_periods_json`. Those pulse windows feed the channel summary rollups, the details
+modal, and the block plan preview inside the export dialog.

--- a/docs/qa/media-planning-process.md
+++ b/docs/qa/media-planning-process.md
@@ -1,0 +1,36 @@
+# Media Planning Workflow QA – 2025-03-01
+
+## Environment
+- Vite dev server (`npm run dev -- --host 0.0.0.0 --port 4173`)
+- Authentication mode: mock (default for local development)
+
+## Test Scenarios
+
+### 1. Authentication Header
+- Launch application and confirm automatic mock sign-in displays planner identity in the header.
+- ✅ Result: Header shows "Signed in as Taylor Planner" with role selector.
+
+### 2. Create New Plan
+- From Dashboard click **New Plan**.
+- ✅ Result: Navigated to plan editor for a new draft plan with default metadata (`New Plan` / auto-generated code).
+
+### 3. Edit Plan Metadata
+- Update plan name to "QA Automation Plan" and code to "QA-2025-SPRING".
+- ✅ Result: Autosave updates persisted and reflected in dashboard summary.
+
+### 4. Submit Plan for Approval
+- Click **Submit for Approval** on the editor.
+- ✅ Result: Status chip switched to `Submitted`, actions update to show **Revert to Draft**.
+
+### 5. Dashboard Status Refresh
+- Return to dashboard and verify the new plan card reflects `Submitted` state.
+- ✅ Result: Card shows latest status and metadata.
+
+### 6. Budget Adjustment Regression
+- Open seeded "Aurora Sparkling FY25 Launch" plan, adjust first line item's planned cost, confirm table updates, then revert value.
+- ✅ Result: Planned cost reflected new value immediately in both allocator and channel table, confirming mutation workflow.
+
+## Noted Limitations
+- The new add-channel scaffolder seeds placeholder vendors, creatives, and flights; planners still need dedicated edit forms to replace the stub data before export.
+- Firebase authentication cannot be exercised locally without providing the required `VITE_FIREBASE_*` variables.
+

--- a/src/api/plans.ts
+++ b/src/api/plans.ts
@@ -1,6 +1,15 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { store } from '@/store';
-import type { Plan } from '@/lib/schemas';
+import type {
+  Plan,
+  Channel,
+  LineItem,
+  Flight,
+  Audience,
+  Vendor,
+  Creative,
+  Tracking,
+} from '@/lib/schemas';
 
 const planKeys = {
   all: ['plans'] as const,
@@ -102,5 +111,51 @@ export function useRevertPlan() {
       client.invalidateQueries({ queryKey: planKeys.all });
       client.setQueryData(planKeys.detail(plan.id), plan);
     },
+  });
+}
+
+export type ChannelFlighting = {
+  lineItem: LineItem;
+  flight?: Flight;
+  audience?: Audience;
+  vendor?: Vendor;
+  creative?: Creative;
+  tracking?: Tracking;
+};
+
+export function useChannelFlightings(planId: string | undefined, channel: Channel) {
+  return useQuery({
+    enabled: Boolean(planId),
+    queryKey: [...planKeys.detail(planId ?? 'unknown'), 'channel-flightings', channel],
+    queryFn: async (): Promise<ChannelFlighting[]> => {
+      if (!planId) return [];
+      const plan = await store.getPlan(planId);
+      if (!plan) {
+        throw new Error('Plan not found');
+      }
+
+      const flightsById = new Map(plan.flights.map((flight) => [flight.flight_id, flight]));
+      const audiencesById = new Map(plan.audiences.map((audience) => [audience.audience_id, audience]));
+      const vendorsById = new Map(plan.vendors.map((vendor) => [vendor.vendor_id, vendor]));
+      const creativesById = new Map(plan.creatives.map((creative) => [creative.creative_id, creative]));
+      const trackingByLine = new Map(plan.tracking.map((tracking) => [tracking.line_item_id, tracking]));
+
+      return plan.lineItems
+        .filter((item) => item.channel === channel)
+        .map((lineItem) => ({
+          lineItem,
+          flight: flightsById.get(lineItem.flight_id),
+          audience: audiencesById.get(lineItem.audience_id),
+          vendor: vendorsById.get(lineItem.vendor_id),
+          creative: creativesById.get(lineItem.creative_id),
+          tracking: trackingByLine.get(lineItem.line_item_id),
+        }))
+        .sort((a, b) => {
+          const aDate = a.flight ? new Date(a.flight.start_date).getTime() : Number.POSITIVE_INFINITY;
+          const bDate = b.flight ? new Date(b.flight.start_date).getTime() : Number.POSITIVE_INFINITY;
+          return aDate - bDate;
+        });
+    },
+    staleTime: 5 * 60 * 1000,
   });
 }

--- a/src/components/ChannelTable.tsx
+++ b/src/components/ChannelTable.tsx
@@ -1,196 +1,808 @@
-import { Fragment, useMemo, useState } from 'react';
-import type { LineItem, Plan } from '@/lib/schemas';
+import { Fragment, ReactNode, useCallback, useMemo, useRef, useState } from 'react';
+import type { Channel, Flight, Plan } from '@/lib/schemas';
+import { channelEnum } from '@/lib/schemas';
 import { Table, THead, TBody, Th, Td } from '@/ui/Table';
-import { currencyFormatter, numberFormatter } from '@/lib/formatters';
-import { formatDateRange } from '@/lib/date';
-import { flags } from '@/app/featureFlags';
+import { Select } from '@/ui/Select';
+import { Button } from '@/ui/Button';
+import { currencyFormatter, numberFormatter, percentFormatter } from '@/lib/formatters';
+import { formatDate } from '@/lib/date';
+import { getChannelExtension } from '@/lib/channelExtensions';
+import { useChannelFlightings, useMutatePlan, type ChannelFlighting } from '@/api/plans';
+import clsx from 'clsx';
+import { FlightDetailsModal } from './FlightDetailsModal';
+import { addChannelDraft } from '@/lib/planBuilders';
+import { AddChannelDialog } from './dialogs/AddChannelDialog';
+import { FlightingScheduleDialog } from './dialogs/FlightingScheduleDialog';
 
-function formatValue(value: unknown): string {
-  if (value === undefined || value === null) return '—';
-  if (Array.isArray(value)) {
-    return value.map((item) => formatValue(item)).join(', ');
-  }
-  if (typeof value === 'object') {
-    return JSON.stringify(value);
-  }
-  if (typeof value === 'number') {
-    if (Number.isInteger(value)) return numberFormatter.format(value);
-    return value.toLocaleString(undefined, { maximumFractionDigits: 2 });
-  }
-  return String(value);
+type ChannelSummary = {
+  channel: Channel;
+  totalCost: number;
+  startDate: string | null;
+  endDate: string | null;
+};
+
+type ChannelTableProps = {
+  plan: Plan;
+  readOnly?: boolean;
+  onChannelChange?: (current: Channel, next: Channel) => void;
+};
+
+type SortKey = 'startDate' | 'endDate' | 'totalCost';
+type SortDirection = 'asc' | 'desc';
+
+type ColumnConfig = {
+  id: string;
+  label: string;
+  render: (data: ChannelFlighting) => ReactNode;
+  align?: 'left' | 'right' | 'center';
+};
+
+function getColumnsForChannel(channel: Channel): ColumnConfig[] {
+  return [
+    {
+      id: 'vendor',
+      label: 'Vendor',
+      render: ({ vendor }) => vendor?.name ?? '—',
+    },
+    {
+      id: 'placement-detail',
+      label: placementLabel(channel),
+      render: (row) => formatPlacementDetail(channel, row),
+    },
+    {
+      id: 'objective',
+      label: 'Objective',
+      render: (row) => formatObjective(channel, row),
+    },
+    {
+      id: 'units',
+      label: 'Units planned',
+      render: (row) => formatUnits(channel, row),
+      align: 'right',
+    },
+    {
+      id: 'cost',
+      label: 'Cost',
+      render: ({ lineItem }) => currencyFormatter.format(lineItem.cost_planned),
+      align: 'right',
+    },
+    {
+      id: 'fees',
+      label: 'Fees',
+      render: (row) => formatFees(row),
+      align: 'right',
+    },
+  ];
 }
 
-function getExtension(lineItem: LineItem) {
-  return (
-    lineItem.ooh_ext ??
-    lineItem.tv_ext ??
-    lineItem.bvod_ext ??
-    lineItem.digital_ext ??
-    lineItem.social_ext ??
-    lineItem.search_ext ??
-    lineItem.audio_ext ??
-    lineItem.podcast_ext ??
-    lineItem.cinema_ext ??
-    lineItem.print_ext ??
-    lineItem.retail_media_ext ??
-    lineItem.influencer_ext ??
-    lineItem.sponsorship_ext ??
-    lineItem.email_dm_ext ??
-    lineItem.gaming_native_ext ??
-    lineItem.affiliate_ext ??
-    undefined
-  );
+function placementLabel(channel: Channel) {
+  switch (channel) {
+    case 'TV':
+    case 'Radio':
+    case 'Streaming_Audio':
+    case 'Cinema':
+      return 'Spot length';
+    case 'OOH':
+    case 'Print':
+    case 'Direct_Mail':
+      return 'Ad size';
+    case 'Retail_Media':
+      return 'Format';
+    case 'Social':
+      return 'Ad format';
+    case 'Digital_Display':
+    case 'Digital_Video':
+    case 'Gaming':
+    case 'Native':
+      return 'Placement';
+    case 'Search':
+      return 'Campaign type';
+    case 'Email':
+      return 'Send platform';
+    case 'Podcast':
+      return 'Show';
+    case 'Influencer':
+      return 'Creator';
+    case 'Sponsorship':
+    case 'Experiential':
+      return 'Property';
+    case 'BVOD_CTV':
+      return 'Platform';
+    case 'Affiliate':
+      return 'Network';
+    default:
+      return 'Placement detail';
+  }
 }
 
-function LineItemDetails({ plan, lineItem }: { plan: Plan; lineItem: LineItem }) {
-  const flight = plan.flights.find((item) => item.flight_id === lineItem.flight_id);
-  const campaign = flight ? plan.campaigns.find((item) => item.campaign_id === flight.campaign_id) : undefined;
-  const audience = plan.audiences.find((item) => item.audience_id === lineItem.audience_id);
-  const vendor = plan.vendors.find((item) => item.vendor_id === lineItem.vendor_id);
-  const creative = plan.creatives.find((item) => item.creative_id === lineItem.creative_id);
-  const tracking = plan.tracking.find((item) => item.line_item_id === lineItem.line_item_id);
-  const actuals = useMemo(
-    () => plan.deliveryActuals.filter((item) => item.line_item_id === lineItem.line_item_id),
-    [plan.deliveryActuals, lineItem.line_item_id],
+function formatPlacementDetail(channel: Channel, row: ChannelFlighting): string {
+  const { lineItem, creative } = row;
+  const extension = getChannelExtension(lineItem);
+
+  switch (channel) {
+    case 'TV':
+      return lineItem.tv_ext?.spot_length_sec
+        ? `${lineItem.tv_ext.spot_length_sec}s`
+        : '—';
+    case 'Radio':
+    case 'Streaming_Audio':
+      return lineItem.audio_ext?.spot_len_sec
+        ? `${lineItem.audio_ext.spot_len_sec}s`
+        : '—';
+    case 'Cinema':
+      return lineItem.cinema_ext?.spot_len_sec
+        ? `${lineItem.cinema_ext.spot_len_sec}s`
+        : '—';
+    case 'OOH':
+      return lineItem.ooh_ext?.format ?? '—';
+    case 'Print':
+      return lineItem.print_ext?.ad_size ?? lineItem.print_ext?.dimensions ?? '—';
+    case 'Direct_Mail':
+      return lineItem.email_dm_ext?.print_specs ?? lineItem.email_dm_ext?.list_source ?? '—';
+    case 'Retail_Media':
+      return (
+        lineItem.retail_media_ext?.onsite_format ??
+        lineItem.retail_media_ext?.offsite_format ??
+        '—'
+      );
+    case 'Social':
+      return (
+        lineItem.social_ext?.ad_format ??
+        lineItem.social_ext?.placements_json?.join(', ') ??
+        '—'
+      );
+    case 'Digital_Display':
+    case 'Digital_Video':
+      return (
+        lineItem.digital_ext?.creative_sizes_json?.join(', ') ??
+        lineItem.digital_ext?.inventory_type ??
+        '—'
+      );
+    case 'Search':
+      return lineItem.search_ext?.campaign_type ?? '—';
+    case 'Email':
+      return lineItem.email_dm_ext?.send_platform ?? '—';
+    case 'Podcast':
+      return lineItem.podcast_ext?.show ?? '—';
+    case 'Influencer':
+      return lineItem.influencer_ext?.creator_handle ?? '—';
+    case 'Sponsorship':
+    case 'Experiential':
+      return lineItem.sponsorship_ext?.property ?? '—';
+    case 'BVOD_CTV':
+      return lineItem.bvod_ext?.platform ?? '—';
+    case 'Gaming':
+    case 'Native':
+      return lineItem.gaming_native_ext?.ad_format ?? lineItem.gaming_native_ext?.title_or_publisher ?? '—';
+    case 'Affiliate':
+      return lineItem.affiliate_ext?.network ?? '—';
+    default:
+      if (typeof extension === 'object' && extension) {
+        const firstValue = Object.values(extension).find((value) => typeof value === 'string');
+        if (typeof firstValue === 'string' && firstValue.trim().length > 0) {
+          return firstValue;
+        }
+      }
+      return creative?.format ?? '—';
+  }
+}
+
+function formatObjective(channel: Channel, row: ChannelFlighting): string {
+  const { lineItem, flight } = row;
+
+  let value: string | undefined | null;
+
+  switch (channel) {
+    case 'TV':
+      value = lineItem.tv_ext?.buy_unit ?? formatGoal(lineItem.goal_type);
+      break;
+    case 'Radio':
+    case 'Streaming_Audio':
+      value = lineItem.audio_ext?.daypart ?? formatGoal(lineItem.goal_type);
+      break;
+    case 'Cinema':
+      value = lineItem.cinema_ext?.package_desc ?? formatGoal(lineItem.goal_type);
+      break;
+    case 'OOH':
+      value = lineItem.ooh_ext?.environment ?? formatGoal(lineItem.goal_type);
+      break;
+    case 'Social':
+      value = lineItem.social_ext?.objective ?? formatPricingModel(lineItem.pricing_model);
+      break;
+    case 'Digital_Display':
+    case 'Digital_Video':
+      value = lineItem.digital_ext?.buy_type ?? formatPricingModel(lineItem.pricing_model);
+      break;
+    case 'Search':
+      value = lineItem.search_ext?.bidding_strategy ?? formatGoal(lineItem.goal_type);
+      break;
+    case 'Retail_Media':
+      value = lineItem.retail_media_ext?.onsite_format
+        ? `On-site ${lineItem.retail_media_ext.onsite_format}`
+        : formatGoal(lineItem.goal_type);
+      break;
+    case 'Influencer':
+      value = lineItem.influencer_ext?.usage_rights_window ?? formatGoal(lineItem.goal_type);
+      break;
+    case 'Sponsorship':
+    case 'Experiential':
+      value = lineItem.sponsorship_ext?.measurement_plan ?? formatGoal(lineItem.goal_type);
+      break;
+    case 'Podcast':
+      value = lineItem.podcast_ext?.ad_position ?? formatGoal(lineItem.goal_type);
+      break;
+    case 'Email':
+      value = lineItem.email_dm_ext?.response_tracking_method ?? formatGoal(lineItem.goal_type);
+      break;
+    case 'Direct_Mail':
+      value = lineItem.email_dm_ext?.drop_date
+        ? `Drop ${formatDate(lineItem.email_dm_ext.drop_date)}`
+        : formatGoal(lineItem.goal_type);
+      break;
+    case 'Gaming':
+    case 'Native':
+      value = lineItem.gaming_native_ext?.subtype ?? formatGoal(lineItem.goal_type);
+      break;
+    case 'Affiliate':
+      value = lineItem.affiliate_ext?.commission_model ?? formatPricingModel(lineItem.pricing_model);
+      break;
+    default:
+      value = flight?.buy_type ?? formatGoal(lineItem.goal_type);
+  }
+
+  if (!value) {
+    return '—';
+  }
+
+  return value;
+}
+
+function formatUnits(channel: Channel, row: ChannelFlighting): string {
+  const { lineItem } = row;
+
+  const channelSpecific = (() => {
+    switch (channel) {
+      case 'TV':
+        return lineItem.tv_ext?.spot_count != null
+          ? `${numberFormatter.format(lineItem.tv_ext.spot_count)} spots`
+          : null;
+      case 'Radio':
+      case 'Streaming_Audio':
+        return lineItem.audio_ext?.spots != null
+          ? `${numberFormatter.format(lineItem.audio_ext.spots)} spots`
+          : null;
+      case 'Cinema':
+        return lineItem.cinema_ext?.screen_count != null
+          ? `${numberFormatter.format(lineItem.cinema_ext.screen_count)} screens`
+          : null;
+      case 'Print':
+        return lineItem.print_ext?.print_run != null
+          ? `${numberFormatter.format(lineItem.print_ext.print_run)} copies`
+          : null;
+      case 'OOH':
+        return lineItem.ooh_ext?.weekly_imps != null
+          ? `${numberFormatter.format(lineItem.ooh_ext.weekly_imps)} weekly imps`
+          : null;
+      case 'Retail_Media':
+        return lineItem.retail_media_ext?.sales_window_days != null
+          ? `${numberFormatter.format(lineItem.retail_media_ext.sales_window_days)} day window`
+          : null;
+      case 'Influencer':
+        return lineItem.influencer_ext?.deliverables_json?.length
+          ? `${numberFormatter.format(lineItem.influencer_ext.deliverables_json.length)} deliverables`
+          : null;
+      default:
+        return null;
+    }
+  })();
+
+  if (channelSpecific) {
+    return channelSpecific;
+  }
+
+  const formattedUnits = numberFormatter.format(lineItem.units_planned);
+  const goal = formatGoal(lineItem.goal_type);
+  return goal ? `${formattedUnits} ${goal}` : formattedUnits;
+}
+
+function formatFees(row: ChannelFlighting): string {
+  const totalFees = calculateFees(row);
+  return totalFees > 0 ? currencyFormatter.format(totalFees) : '—';
+}
+
+function calculateFees({ lineItem }: ChannelFlighting): number {
+  const extension = getChannelExtension(lineItem);
+  if (!extension || typeof extension !== 'object') {
+    return 0;
+  }
+  return collectNumericFees(extension as Record<string, unknown>);
+}
+
+function collectNumericFees(payload: Record<string, unknown>): number {
+  return Object.entries(payload).reduce((total, [key, value]) => {
+    if (typeof value === 'number' && /(_cost|_fee|commission)/i.test(key)) {
+      return total + value;
+    }
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return total + collectNumericFees(value as Record<string, unknown>);
+    }
+    return total;
+  }, 0);
+}
+
+function resolveFlightStart(flight?: Flight | null): string | null {
+  if (!flight) return null;
+  const periods = flight.active_periods_json ?? [];
+  if (periods.length === 0) {
+    return flight.start_date;
+  }
+  const sorted = [...periods].sort(
+    (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
   );
-  const extension = getExtension(lineItem);
+  return sorted[0]?.start ?? flight.start_date;
+}
 
-  const extensionEntries = extension ? Object.entries(extension).map(([key, value]) => [key, formatValue(value)]) : [];
+function resolveFlightEnd(flight?: Flight | null): string | null {
+  if (!flight) return null;
+  const periods = flight.active_periods_json ?? [];
+  if (periods.length === 0) {
+    return flight.end_date;
+  }
+  const sorted = [...periods].sort((a, b) => new Date(a.end).getTime() - new Date(b.end).getTime());
+  return sorted[sorted.length - 1]?.end ?? flight.end_date;
+}
 
-  const totals = actuals.reduce(
-    (acc, row) => ({
-      impressions: acc.impressions + (row.impressions ?? 0),
-      clicks: acc.clicks + (row.clicks ?? 0),
-      conversions: acc.conversions + (row.conversions ?? 0),
-      cost: acc.cost + (row.actual_cost ?? 0),
-    }),
-    { impressions: 0, clicks: 0, conversions: 0, cost: 0 },
+function formatGoal(goal?: string) {
+  if (!goal) return '';
+  return goal.replace(/_/g, ' ');
+}
+
+function formatPricingModel(model: string) {
+  return model.replace(/_/g, ' ');
+}
+
+function buildChannelSummaries(plan: Plan): ChannelSummary[] {
+  const flightsById = new Map(plan.flights.map((flight) => [flight.flight_id, flight]));
+  const summaryMap = new Map<Channel, ChannelSummary>();
+
+  for (const item of plan.lineItems) {
+    const summary = summaryMap.get(item.channel) ?? {
+      channel: item.channel,
+      totalCost: 0,
+      startDate: null,
+      endDate: null,
+    };
+
+    const flight = flightsById.get(item.flight_id);
+    summary.totalCost += item.cost_planned;
+
+    if (flight) {
+      const start = resolveFlightStart(flight);
+      const end = resolveFlightEnd(flight);
+      if (start) {
+        summary.startDate = summary.startDate
+          ? new Date(summary.startDate) <= new Date(start)
+            ? summary.startDate
+            : start
+          : start;
+      }
+      if (end) {
+        summary.endDate = summary.endDate
+          ? new Date(summary.endDate) >= new Date(end)
+            ? summary.endDate
+            : end
+          : end;
+      }
+    }
+
+    summaryMap.set(item.channel, summary);
+  }
+
+  return Array.from(summaryMap.values());
+}
+
+function sortSummaries(rows: ChannelSummary[], key: SortKey, direction: SortDirection) {
+  const sorted = [...rows].sort((a, b) => {
+    const multiplier = direction === 'asc' ? 1 : -1;
+
+    if (key === 'totalCost') {
+      return (a.totalCost - b.totalCost) * multiplier;
+    }
+
+    const aDate = key === 'startDate' ? a.startDate : a.endDate;
+    const bDate = key === 'startDate' ? b.startDate : b.endDate;
+    if (!aDate && !bDate) return 0;
+    if (!aDate) return 1 * multiplier;
+    if (!bDate) return -1 * multiplier;
+    return (new Date(aDate).getTime() - new Date(bDate).getTime()) * multiplier;
+  });
+
+  return sorted;
+}
+
+export function ChannelTable({ plan, readOnly = false, onChannelChange }: ChannelTableProps) {
+  const [sortKey, setSortKey] = useState<SortKey>('startDate');
+  const [direction, setDirection] = useState<SortDirection>('asc');
+  const [expanded, setExpanded] = useState<Set<Channel>>(() => new Set());
+  const [activeFlight, setActiveFlight] = useState<ChannelFlighting | null>(null);
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const [scheduleTarget, setScheduleTarget] = useState<ChannelFlighting | null>(null);
+  const detailTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const scheduleTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const mutatePlan = useMutatePlan();
+
+  const summaries = useMemo(() => buildChannelSummaries(plan), [plan]);
+  const sorted = useMemo(() => sortSummaries(summaries, sortKey, direction), [summaries, sortKey, direction]);
+  const totalPlanCost = useMemo(
+    () => plan.lineItems.reduce((total, item) => total + item.cost_planned, 0),
+    [plan.lineItems],
+  );
+  const channelLabels = useMemo(() => {
+    // Precompute channel labels so repeated replace operations don't thrash renders.
+    return new Map(channelEnum.options.map((channel) => [channel, channel.replace(/_/g, ' ')]));
+  }, []);
+
+  const liveMessage = useMemo(
+    // Keep screen reader announcements stable whenever sorting changes.
+    () =>
+      sorted
+        .map((summary) => {
+          const label = channelLabels.get(summary.channel) ?? summary.channel;
+          const start = summary.startDate ? formatDate(summary.startDate) : 'No start date';
+          const end = summary.endDate ? formatDate(summary.endDate) : 'No end date';
+          return `${label}: ${start} to ${end}`;
+        })
+        .join('. '),
+    [channelLabels, sorted],
+  );
+
+  const toggleSort = useCallback(
+    (key: SortKey) => {
+      if (sortKey === key) {
+        setDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+      } else {
+        setSortKey(key);
+        setDirection('asc');
+      }
+    },
+    [sortKey],
+  );
+
+  const handleChannelSelect = useCallback(
+    (current: Channel, next: Channel) => {
+      if (readOnly || current === next) return;
+      // Defer persistence to the parent so we can respect existing data flows.
+      onChannelChange?.(current, next);
+    },
+    [onChannelChange, readOnly],
+  );
+
+  const handleToggle = useCallback((channel: Channel) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(channel)) {
+        next.delete(channel);
+      } else {
+        next.add(channel);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleAddChannel = useCallback(
+    async (channel: Channel) => {
+      if (readOnly) return;
+      const nextPlan = addChannelDraft(plan, channel);
+      await mutatePlan.mutateAsync(nextPlan);
+      setExpanded((prev) => {
+        const next = new Set(prev);
+        next.add(channel);
+        return next;
+      });
+      setAddDialogOpen(false);
+    },
+    [mutatePlan, plan, readOnly],
+  );
+
+  const handleSaveSchedule = useCallback(
+    async (flightId: string, periods: { start: string; end: string }[]) => {
+      const nextPlan: Plan = {
+        ...plan,
+        flights: plan.flights.map((flight) =>
+          flight.flight_id === flightId ? { ...flight, active_periods_json: periods } : flight,
+        ),
+      };
+      await mutatePlan.mutateAsync(nextPlan);
+      setScheduleTarget(null);
+      scheduleTriggerRef.current?.focus();
+    },
+    [mutatePlan, plan],
   );
 
   return (
-    <div className="space-y-4 rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+    <section aria-labelledby="channel-table-heading" className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <p className="text-xs uppercase tracking-wide text-slate-500">Campaign</p>
-          <p className="font-medium text-slate-800">{campaign?.brand ?? '—'}</p>
-          <p className="text-xs text-slate-500">{campaign?.objective ?? 'No objective recorded'}</p>
+          <h2 id="channel-table-heading" className="text-lg font-semibold text-slate-900">
+            Channel allocations
+          </h2>
+          <p className="text-sm text-slate-500">{summaries.length} channels</p>
         </div>
-        <div>
-          <p className="text-xs uppercase tracking-wide text-slate-500">Audience</p>
-          <p className="font-medium text-slate-800">{audience?.definition ?? '—'}</p>
-          <p className="text-xs text-slate-500">Segments: {formatValue(audience?.segments_json)}</p>
-        </div>
-        <div>
-          <p className="text-xs uppercase tracking-wide text-slate-500">Creative</p>
-          <p className="font-medium text-slate-800">{creative?.ad_name ?? '—'}</p>
-          <p className="text-xs text-slate-500">Format: {creative?.format ?? '—'}</p>
-        </div>
-        <div>
-          <p className="text-xs uppercase tracking-wide text-slate-500">Vendor Contact</p>
-          <p className="font-medium text-slate-800">{vendor?.name ?? '—'}</p>
-          <p className="text-xs text-slate-500">{formatValue(vendor?.contact_json)}</p>
-        </div>
-        <div>
-          <p className="text-xs uppercase tracking-wide text-slate-500">Tracking</p>
-          <p className="font-medium text-slate-800">{tracking?.ad_server ?? '—'}</p>
-          <p className="text-xs text-slate-500">Verification: {tracking?.verification_vendor ?? '—'}</p>
-        </div>
-        <div>
-          <p className="text-xs uppercase tracking-wide text-slate-500">Actuals (to date)</p>
-          <p className="font-medium text-slate-800">
-            {numberFormatter.format(totals.impressions)} imp • {numberFormatter.format(totals.clicks)} clicks
-          </p>
-          <p className="text-xs text-slate-500">
-            {numberFormatter.format(totals.conversions)} conv • {currencyFormatter.format(totals.cost)} cost
-          </p>
-        </div>
+        {!readOnly ? (
+          <Button onClick={() => setAddDialogOpen(true)}>Add channel</Button>
+        ) : null}
       </div>
-      {extensionEntries.length > 0 ? (
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Channel Details</p>
-          <dl className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
-            {extensionEntries.map(([key, value]) => (
-              <div key={key} className="rounded border border-slate-200 bg-white p-2">
-                <dt className="text-xs uppercase tracking-wide text-slate-400">{key.replace(/_/g, ' ')}</dt>
-                <dd className="text-sm font-medium text-slate-800">{value}</dd>
-              </div>
-            ))}
-          </dl>
-        </div>
-      ) : null}
-    </div>
+      {summaries.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600">
+          No channels yet. Add line items to populate this plan.
+        </p>
+      ) : (
+        <Fragment>
+          <Table className="max-h-[28rem]">
+            <THead sticky>
+              <tr>
+                <Th ariaSort="none">Channel</Th>
+                <Th
+                  ariaSort={
+                    sortKey === 'startDate' ? (direction === 'asc' ? 'ascending' : 'descending') : 'none'
+                  }
+                >
+                  <SortButton
+                    label="Start date"
+                    active={sortKey === 'startDate'}
+                    direction={direction}
+                    onClick={() => toggleSort('startDate')}
+                  />
+                </Th>
+                <Th
+                  ariaSort={
+                    sortKey === 'endDate' ? (direction === 'asc' ? 'ascending' : 'descending') : 'none'
+                  }
+                >
+                  <SortButton
+                    label="End date"
+                    active={sortKey === 'endDate'}
+                    direction={direction}
+                    onClick={() => toggleSort('endDate')}
+                  />
+                </Th>
+                <Th
+                  ariaSort={
+                    sortKey === 'totalCost' ? (direction === 'asc' ? 'ascending' : 'descending') : 'none'
+                  }
+                >
+                  <SortButton
+                    label="Cost"
+                    active={sortKey === 'totalCost'}
+                    direction={direction}
+                    onClick={() => toggleSort('totalCost')}
+                  />
+                </Th>
+                <Th ariaSort="none">Budget %</Th>
+                <Th ariaSort="none">Actions</Th>
+              </tr>
+            </THead>
+            <TBody>
+              {sorted.map((summary) => {
+                const panelId = `channel-${summary.channel}-panel`;
+                const isExpanded = expanded.has(summary.channel);
+                const share = totalPlanCost > 0 ? summary.totalCost / totalPlanCost : 0;
+
+                return (
+                  <Fragment key={summary.channel}>
+                    <tr className="bg-white hover:bg-slate-50 focus-within:bg-slate-50">
+                      <Td>
+                        <Select
+                          aria-label={`Channel ${channelLabels.get(summary.channel) ?? summary.channel}`}
+                          value={summary.channel}
+                          disabled={readOnly || !onChannelChange}
+                          onChange={(event) =>
+                            handleChannelSelect(summary.channel, event.currentTarget.value as Channel)
+                          }
+                        >
+                          {channelEnum.options.map((channel) => (
+                            <option key={channel} value={channel}>
+                              {channelLabels.get(channel) ?? channel.replace(/_/g, ' ')}
+                            </option>
+                          ))}
+                        </Select>
+                      </Td>
+                      <Td>{summary.startDate ? formatDate(summary.startDate) : '—'}</Td>
+                      <Td>{summary.endDate ? formatDate(summary.endDate) : '—'}</Td>
+                      <Td align="right">{currencyFormatter.format(summary.totalCost)}</Td>
+                      <Td align="right">{percentFormatter.format(share)}</Td>
+                      <Td align="right">
+                        <Button
+                          variant="ghost"
+                          aria-expanded={isExpanded}
+                          aria-controls={panelId}
+                          onClick={() => handleToggle(summary.channel)}
+                          aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${summary.channel} channel flightings`}
+                        >
+                          {isExpanded ? 'Hide flightings' : 'View flightings'}
+                        </Button>
+                      </Td>
+                    </tr>
+                    {isExpanded ? (
+                      <tr id={panelId}>
+                        <Td colSpan={5}>
+                          <div className="py-4">
+                            <FlightingsSection
+                              plan={plan}
+                              channel={summary.channel}
+                              readOnly={readOnly}
+                              onViewDetails={(row, button) => {
+                                detailTriggerRef.current = button;
+                                setActiveFlight(row);
+                              }}
+                              onEditSchedule={(row, button) => {
+                                if (!row.flight || readOnly) return;
+                                scheduleTriggerRef.current = button;
+                                setScheduleTarget(row);
+                              }}
+                            />
+                          </div>
+                        </Td>
+                      </tr>
+                    ) : null}
+                  </Fragment>
+                );
+              })}
+            </TBody>
+          </Table>
+          <span className="sr-only" aria-live="polite">
+            {liveMessage}
+          </span>
+        </Fragment>
+      )}
+      <FlightDetailsModal
+        flighting={activeFlight}
+        open={Boolean(activeFlight)}
+        onClose={() => {
+          setActiveFlight(null);
+          detailTriggerRef.current?.focus();
+        }}
+      />
+      <FlightingScheduleDialog
+        flighting={scheduleTarget}
+        open={Boolean(scheduleTarget)}
+        onClose={() => {
+          setScheduleTarget(null);
+          scheduleTriggerRef.current?.focus();
+        }}
+        onSave={handleSaveSchedule}
+      />
+      <AddChannelDialog
+        open={addDialogOpen}
+        busy={mutatePlan.isPending}
+        onClose={() => setAddDialogOpen(false)}
+        onAdd={handleAddChannel}
+      />
+    </section>
   );
 }
 
-export function ChannelTable({ plan }: { plan: Plan; readOnly?: boolean }) {
-  const [expandedId, setExpandedId] = useState<string | null>(null);
-  const enableDetails = flags.mediaModelV1;
+type SortButtonProps = {
+  label: string;
+  active: boolean;
+  direction: SortDirection;
+  onClick: () => void;
+};
 
-  const toggle = (id: string) => {
-    if (!enableDetails) return;
-    setExpandedId((current) => (current === id ? null : id));
-  };
-
+function SortButton({ label, active, direction, onClick }: SortButtonProps) {
   return (
-    <Table>
-      <THead>
-        <tr>
-          <Th>Line Item</Th>
-          <Th>Campaign</Th>
-          <Th>Flight</Th>
-          <Th>Channel</Th>
-          <Th>Vendor</Th>
-          <Th>Pricing</Th>
-          <Th align="right">Units Planned</Th>
-          <Th align="right">Planned Cost</Th>
-        </tr>
-      </THead>
-      <TBody>
-        {plan.lineItems.map((lineItem) => {
-          const flight = plan.flights.find((item) => item.flight_id === lineItem.flight_id);
-          const campaign = flight
-            ? plan.campaigns.find((item) => item.campaign_id === flight.campaign_id)
-            : undefined;
-          const vendor = plan.vendors.find((item) => item.vendor_id === lineItem.vendor_id);
-          const creative = plan.creatives.find((item) => item.creative_id === lineItem.creative_id);
-          const isExpanded = expandedId === lineItem.line_item_id;
-
-          return (
-            <Fragment key={lineItem.line_item_id}>
-              <tr key={lineItem.line_item_id} className="bg-white hover:bg-slate-50">
-                <Td>
-                  {enableDetails ? (
-                    <button
-                      type="button"
-                      onClick={() => toggle(lineItem.line_item_id)}
-                      className="flex w-full items-center justify-between gap-3 text-left text-sm font-medium text-slate-800"
-                    >
-                      <span>{creative?.ad_name ?? lineItem.line_item_id}</span>
-                      <span className="text-xs text-indigo-600">{isExpanded ? 'Hide' : 'View'} details</span>
-                    </button>
-                  ) : (
-                    <span className="text-sm font-medium text-slate-800">{creative?.ad_name ?? lineItem.line_item_id}</span>
-                  )}
-                </Td>
-                <Td>{campaign?.brand ?? '—'}</Td>
-                <Td>{flight ? formatDateRange(flight.start_date, flight.end_date) : '—'}</Td>
-                <Td>{lineItem.channel}</Td>
-                <Td>{vendor?.name ?? '—'}</Td>
-                <Td>{`${lineItem.pricing_model} @ ${lineItem.rate_unit}`}</Td>
-                <Td align="right">{numberFormatter.format(lineItem.units_planned)}</Td>
-                <Td align="right">{currencyFormatter.format(lineItem.cost_planned)}</Td>
-              </tr>
-              {enableDetails && isExpanded ? (
-                <tr>
-                  <Td colSpan={8} className="bg-slate-50">
-                    <LineItemDetails plan={plan} lineItem={lineItem} />
-                  </Td>
-                </tr>
-              ) : null}
-            </Fragment>
-          );
-        })}
-      </TBody>
-    </Table>
+    <button
+      type="button"
+      className={clsx('flex items-center gap-1 text-left text-sm font-medium text-slate-600', {
+        'text-slate-900': active,
+      })}
+      aria-label={`${label} ${active ? (direction === 'asc' ? 'ascending' : 'descending') : 'unsorted'}`}
+      onClick={onClick}
+    >
+      {label}
+      <span aria-hidden="true" className="text-xs text-slate-400">
+        {active ? (direction === 'asc' ? '▲' : '▼') : '↕'}
+      </span>
+    </button>
   );
+}
+
+type FlightingsSectionProps = {
+  plan: Plan;
+  channel: Channel;
+  readOnly: boolean;
+  onViewDetails: (row: ChannelFlighting, trigger: HTMLButtonElement) => void;
+  onEditSchedule: (row: ChannelFlighting, trigger: HTMLButtonElement) => void;
+};
+
+function FlightingsSection({ plan, channel, readOnly, onViewDetails, onEditSchedule }: FlightingsSectionProps) {
+  const { data, isLoading, isError, refetch, isRefetching } = useChannelFlightings(plan.id, channel);
+
+  let content: ReactNode;
+
+  if (isLoading || isRefetching) {
+    content = (
+      <p className="p-4 text-sm text-slate-500" role="status">
+        Loading flightings…
+      </p>
+    );
+  } else if (isError) {
+    content = (
+      <div className="space-y-2 rounded-lg border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700" role="alert">
+        <p>We were unable to load the {channel.replace(/_/g, ' ')} flightings.</p>
+        <Button variant="secondary" onClick={() => void refetch()}>
+          Retry
+        </Button>
+      </div>
+    );
+  } else if (!data || data.length === 0) {
+    content = (
+      <p className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600">
+        No flightings yet. Add a line item for this channel to see it here.
+      </p>
+    );
+  } else {
+    const columns = getColumnsForChannel(channel);
+
+    content = (
+      <div className="overflow-hidden rounded-lg border border-slate-200">
+        <table
+          className="min-w-full divide-y divide-slate-200 text-sm text-slate-700"
+          aria-label={`${channel.replace(/_/g, ' ')} flightings`}
+        >
+          <thead className="bg-slate-100 text-xs uppercase tracking-wide text-slate-500">
+            <tr>
+              {columns.map((column) => (
+                <th key={column.id} className="px-4 py-2 text-left font-medium">
+                  {column.label}
+                </th>
+              ))}
+              <th className="px-4 py-2 text-right font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200">
+            {data.map((row) => (
+              <tr key={row.lineItem.line_item_id} className="bg-white hover:bg-slate-50">
+                  {columns.map((column) => (
+                    <td
+                      key={column.id}
+                      className={clsx('px-4 py-2', {
+                        'text-right': column.align === 'right',
+                        'text-center': column.align === 'center',
+                        'text-left': column.align === 'left' || !column.align,
+                      })}
+                    >
+                      {column.render(row)}
+                    </td>
+                  ))}
+                <td className="px-4 py-2 text-right">
+                  <div className="flex flex-wrap justify-end gap-2">
+                    <Button
+                      variant="secondary"
+                      disabled={readOnly || !row.flight}
+                      onClick={(event) => {
+                        onEditSchedule(row, event.currentTarget);
+                      }}
+                    >
+                      Edit schedule
+                    </Button>
+                    <Button
+                      variant="secondary"
+                      onClick={(event) => {
+                        onViewDetails(row, event.currentTarget);
+                      }}
+                    >
+                      View additional details
+                    </Button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  return <div aria-live="polite">{content}</div>;
 }

--- a/src/components/ExportDialog.tsx
+++ b/src/components/ExportDialog.tsx
@@ -1,11 +1,14 @@
-import { useState } from 'react';
-import type { Plan } from '@/lib/schemas';
+import { Fragment, useMemo, useState } from 'react';
+import type { Channel, Plan } from '@/lib/schemas';
 import { Modal } from '@/ui/Modal';
 import { Button } from '@/ui/Button';
 import { blockPlanTemplates } from '@/exporters/blockPlan/templates';
 import { buildPdf } from '@/exporters/blockPlan/pdf';
 import { buildExcelWorkbook } from '@/exporters/blockPlan/excel';
 import { exportFilename } from '@/exporters/blockPlan/common';
+import { enumerateWeeks, formatDateRange, toIsoDate } from '@/lib/date';
+import { currencyFormatter } from '@/lib/formatters';
+import clsx from 'clsx';
 
 function downloadBlob(filename: string, blob: Blob) {
   const link = document.createElement('a');
@@ -13,6 +16,170 @@ function downloadBlob(filename: string, blob: Blob) {
   link.download = filename;
   link.click();
   setTimeout(() => URL.revokeObjectURL(link.href), 0);
+}
+
+type BlockPlanRow = {
+  lineItemId: string;
+  channel: Channel;
+  label: string;
+  flightRange: string;
+  activeWeeks: Set<string>;
+  startTimestamp: number;
+  totalCost: number;
+};
+
+function BlockPlanMatrix({ plan }: { plan: Plan }) {
+  const { weeks, groups } = useMemo(() => buildBlockPlan(plan), [plan]);
+
+  if (weeks.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600">
+        No flightings scheduled yet. Add line items to populate the block plan preview.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-semibold text-slate-800">Block plan preview</h3>
+          <p className="text-xs text-slate-500">Weeks run Sunday through Saturday. Highlighted cells indicate planned activity.</p>
+        </div>
+        <div className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
+          {weeks.length} weeks
+        </div>
+      </div>
+      <div className="overflow-auto rounded-lg border border-slate-200">
+        <table className="min-w-full border-collapse text-xs text-slate-700">
+          <thead className="bg-slate-100 text-[0.7rem] uppercase tracking-wide text-slate-500">
+            <tr>
+              <th className="w-64 px-3 py-2 text-left">Channel / Flight</th>
+              {weeks.map((week) => (
+                <th key={week.key} className="px-3 py-2 text-center font-medium">
+                  {formatDateRange(toIsoDate(week.start), toIsoDate(week.end))}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from(groups.entries()).map(([channel, rows]) => {
+              const channelTotal = rows.reduce((sum, row) => sum + row.totalCost, 0);
+              return (
+                <Fragment key={channel}>
+                  <tr className="bg-slate-50">
+                    <th colSpan={weeks.length + 1} className="px-3 py-2 text-left text-slate-700">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <span className="font-semibold">{channel.replace(/_/g, ' ')}</span>
+                        <span className="text-xs text-slate-500">
+                          {currencyFormatter.format(channelTotal)} planned
+                        </span>
+                      </div>
+                    </th>
+                  </tr>
+                  {rows.map((row) => (
+                    <tr key={row.lineItemId} className="border-b border-slate-100">
+                      <th className="bg-white px-3 py-2 text-left font-medium text-slate-700">
+                        <div className="space-y-1">
+                          <span>{row.label}</span>
+                          <span className="block text-[0.7rem] text-slate-500">{row.flightRange}</span>
+                        </div>
+                      </th>
+                      {weeks.map((week) => {
+                        const active = row.activeWeeks.has(week.key);
+                        const cellLabel = `${row.label} ${active ? 'in market' : 'dark'} ${formatDateRange(
+                          toIsoDate(week.start),
+                          toIsoDate(week.end),
+                        )}`;
+                        return (
+                          <td
+                            key={`${row.lineItemId}-${week.key}`}
+                            className={clsx('px-3 py-2 text-center align-middle', {
+                              'bg-indigo-100 font-semibold text-indigo-900': active,
+                              'text-slate-400': !active,
+                            })}
+                            aria-label={cellLabel}
+                          >
+                            {active ? '●' : '–'}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function buildBlockPlan(plan: Plan) {
+  const flightsById = new Map(plan.flights.map((flight) => [flight.flight_id, flight]));
+  const vendorsById = new Map(plan.vendors.map((vendor) => [vendor.vendor_id, vendor]));
+
+  let earliest: string | null = null;
+  let latest: string | null = null;
+
+  const rows: BlockPlanRow[] = [];
+
+  for (const item of plan.lineItems) {
+    const flight = flightsById.get(item.flight_id);
+    if (!flight) continue;
+
+    const periods =
+      flight.active_periods_json && flight.active_periods_json.length > 0
+        ? flight.active_periods_json
+        : [{ start: flight.start_date, end: flight.end_date }];
+
+    for (const period of periods) {
+      if (!earliest || new Date(period.start) < new Date(earliest)) {
+        earliest = period.start;
+      }
+      if (!latest || new Date(period.end) > new Date(latest)) {
+        latest = period.end;
+      }
+    }
+
+    const activeWeeks = new Set<string>();
+    periods.forEach((period) => {
+      enumerateWeeks(new Date(period.start), new Date(period.end)).forEach((week) => {
+        activeWeeks.add(week.key);
+      });
+    });
+
+    rows.push({
+      lineItemId: item.line_item_id,
+      channel: item.channel,
+      label: vendorsById.get(item.vendor_id)?.name ?? item.line_item_id,
+      flightRange: formatDateRange(flight.start_date, flight.end_date),
+      activeWeeks,
+      startTimestamp: new Date(flight.start_date).getTime(),
+      totalCost: item.cost_planned,
+    });
+  }
+
+  if (!earliest || !latest) {
+    return { weeks: [] as ReturnType<typeof enumerateWeeks>, groups: new Map<Channel, BlockPlanRow[]>() };
+  }
+
+  const weeks = enumerateWeeks(new Date(earliest), new Date(latest));
+  const groups = new Map<Channel, BlockPlanRow[]>();
+
+  for (const row of rows) {
+    const bucket = groups.get(row.channel) ?? [];
+    bucket.push(row);
+    groups.set(row.channel, bucket);
+  }
+
+  groups.forEach((list, channel) => {
+    list.sort((a, b) => a.startTimestamp - b.startTimestamp);
+    groups.set(channel, list);
+  });
+
+  return { weeks, groups };
 }
 
 export function ExportDialog({ plan, open, onClose }: { plan: Plan; open: boolean; onClose: () => void }) {
@@ -59,22 +226,31 @@ export function ExportDialog({ plan, open, onClose }: { plan: Plan; open: boolea
         </div>
       }
     >
-      <div className="space-y-3">
+      <div className="space-y-6">
         <p className="text-sm text-slate-600">
           Plan exports include status, approver, pacing warnings, and a block plan matrix. Draft plans include a watermark.
         </p>
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
-          {blockPlanTemplates.map((template) => (
-            <button
-              key={template.id}
-              type="button"
-              onClick={() => setSelectedTemplate(template)}
-              className={`rounded-lg border p-3 text-left text-sm shadow-sm transition hover:border-indigo-400 ${selectedTemplate.id === template.id ? 'border-indigo-500 bg-indigo-50' : 'border-slate-200 bg-white'}`}
-            >
-              <div className="font-semibold text-slate-700">{template.name}</div>
-              <div className="mt-1 text-xs text-slate-500">{template.description}</div>
-            </button>
-          ))}
+        <BlockPlanMatrix plan={plan} />
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold text-slate-800">Export templates</h3>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+            {blockPlanTemplates.map((template) => (
+              <button
+                key={template.id}
+                type="button"
+                onClick={() => setSelectedTemplate(template)}
+                className={clsx(
+                  'rounded-lg border p-3 text-left text-sm shadow-sm transition hover:border-indigo-400',
+                  selectedTemplate.id === template.id
+                    ? 'border-indigo-500 bg-indigo-50'
+                    : 'border-slate-200 bg-white',
+                )}
+              >
+                <div className="font-semibold text-slate-700">{template.name}</div>
+                <div className="mt-1 text-xs text-slate-500">{template.description}</div>
+              </button>
+            ))}
+          </div>
         </div>
       </div>
     </Modal>

--- a/src/components/FlightDetailsModal.tsx
+++ b/src/components/FlightDetailsModal.tsx
@@ -1,0 +1,171 @@
+import { formatDate, formatDateRange } from '@/lib/date';
+import { currencyFormatter, numberFormatter } from '@/lib/formatters';
+import { Modal } from '@/ui/Modal';
+import { Button } from '@/ui/Button';
+import type { ChannelFlighting } from '@/api/plans';
+import { extensionKeyByChannel } from '@/lib/channelExtensions';
+
+type FlightDetailsModalProps = {
+  flighting: ChannelFlighting | null;
+  open: boolean;
+  onClose: () => void;
+};
+
+type Row = { label: string; value: string };
+
+type Section = { title: string; rows: Row[] };
+
+export function FlightDetailsModal({ flighting, open, onClose }: FlightDetailsModalProps) {
+  if (!flighting || !flighting.lineItem) {
+    return null;
+  }
+
+  const { lineItem, flight, vendor, audience, tracking, creative } = flighting;
+  const extensionKey = extensionKeyByChannel[lineItem.channel];
+  const extension = extensionKey
+    ? (lineItem[extensionKey] as Record<string, unknown> | undefined)
+    : undefined;
+
+  const core: Row[] = compact([
+    { label: 'Line item ID', value: lineItem.line_item_id },
+    { label: 'Channel', value: lineItem.channel.replace(/_/g, ' ') },
+    vendor?.name ? { label: 'Vendor', value: vendor.name } : null,
+    creative?.ad_name ? { label: 'Creative', value: creative.ad_name } : null,
+    flight
+      ? {
+          label: 'Flight window',
+          value: `${formatDate(flight.start_date)} – ${formatDate(flight.end_date)}`,
+        }
+      : null,
+    flight?.active_periods_json?.length
+      ? {
+          label: 'Active periods',
+          value: flight.active_periods_json
+            .map((period) => formatDateRange(period.start, period.end))
+            .join(', '),
+        }
+      : null,
+    { label: 'Planned cost', value: currencyFormatter.format(lineItem.cost_planned) },
+  ]);
+
+  const targeting: Row[] = compact([
+    audience?.definition ? { label: 'Audience', value: audience.definition } : null,
+    audience?.geo ? { label: 'Geography', value: audience.geo } : null,
+    lineItem.goal_type ? { label: 'Goal type', value: lineItem.goal_type.replace(/_/g, ' ') } : null,
+  ]);
+
+  const buying: Row[] = compact([
+    { label: 'Pricing model', value: lineItem.pricing_model },
+    {
+      label: 'Rate',
+      value: formatRate(lineItem.rate_numeric, lineItem.rate_unit),
+    },
+    { label: 'Units planned', value: numberFormatter.format(lineItem.units_planned) },
+    lineItem.pacing ? { label: 'Pacing', value: lineItem.pacing } : null,
+  ]);
+
+  const trackingRows: Row[] = compact([
+    tracking?.ad_server ? { label: 'Ad server', value: tracking.ad_server } : null,
+    tracking?.verification_vendor
+      ? { label: 'Verification', value: tracking.verification_vendor }
+      : null,
+    tracking?.conversion_source
+      ? { label: 'Conversion source', value: tracking.conversion_source }
+      : null,
+    lineItem.notes ? { label: 'Notes', value: lineItem.notes } : null,
+  ]);
+
+  const extensionRows: Row[] = extension
+    ? Object.entries(extension).map(([key, value]) => ({
+        label: startCase(key.replace(/_ext$/, '')),
+        value: formatValue(value),
+      }))
+    : [];
+
+  const sections: Section[] = [
+    { title: 'Core', rows: core },
+    { title: 'Targeting', rows: targeting },
+    { title: 'Buying & Units', rows: buying },
+    { title: 'Tracking & Notes', rows: trackingRows },
+  ];
+
+  if (extensionRows.length > 0) {
+    sections.push({ title: 'Channel extension', rows: extensionRows });
+  }
+
+  return (
+    <Modal
+      title={`${lineItem.channel.replace(/_/g, ' ')} flighting details`}
+      description="Review the structured payload powering this placement."
+      open={open}
+      onClose={onClose}
+      footer={
+        <div className="flex justify-end">
+          <Button onClick={onClose}>Close</Button>
+        </div>
+      }
+    >
+      <div className="space-y-6">
+        {sections.map((section) =>
+          section.rows.length > 0 ? (
+            <section key={section.title} className="space-y-3">
+              <h3 className="text-sm font-semibold text-slate-800">{section.title}</h3>
+              <dl className="grid grid-cols-1 gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
+                {section.rows.map((row) => (
+                  <div key={`${section.title}-${row.label}`} className="space-y-1">
+                    <dt className="text-xs uppercase tracking-wide text-slate-500">{row.label}</dt>
+                    <dd className="text-slate-900">{row.value}</dd>
+                  </div>
+                ))}
+              </dl>
+            </section>
+          ) : null,
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+function compact<T>(items: (T | null | undefined)[]): T[] {
+  return items.filter((item): item is T => item != null);
+}
+
+function formatRate(rate: number, unit: string) {
+  if (Number.isNaN(rate)) return '—';
+  const formatter = new Intl.NumberFormat('en-AU', {
+    style: 'currency',
+    currency: 'AUD',
+    maximumFractionDigits: 2,
+  });
+  const formatted = formatter.format(rate);
+  return `${formatted} ${unit}`;
+}
+
+function startCase(value: string) {
+  return value
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (match) => match.toUpperCase())
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function formatValue(value: unknown): string {
+  if (value == null) return '—';
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (typeof value === 'number') return numberFormatter.format(value);
+  if (typeof value === 'string') {
+    if (/^\d{4}-\d{2}-\d{2}/.test(value)) {
+      return formatDate(value);
+    }
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => formatValue(entry)).join(', ');
+  }
+  if (typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>)
+      .map(([key, entry]) => `${startCase(key)}: ${formatValue(entry)}`)
+      .join('; ');
+  }
+  return String(value);
+}

--- a/src/components/MediaPlanOverviewCard.tsx
+++ b/src/components/MediaPlanOverviewCard.tsx
@@ -1,0 +1,75 @@
+import { useMemo } from 'react';
+import type { Plan } from '@/lib/schemas';
+import { Card } from '@/ui/Card';
+import { Button } from '@/ui/Button';
+import { currencyFormatter } from '@/lib/formatters';
+import { formatDate } from '@/lib/date';
+
+type MediaPlanOverviewCardProps = {
+  plan: Plan;
+  onEdit?: () => void;
+};
+
+export function MediaPlanOverviewCard({ plan, onEdit }: MediaPlanOverviewCardProps) {
+  const { totalCost, startDate, endDate } = useMemo(() => {
+    const total = plan.lineItems.reduce((sum, item) => sum + item.cost_planned, 0);
+    const starts = plan.flights.map((flight) => flight.start_date);
+    const ends = plan.flights.map((flight) => flight.end_date);
+
+    const start = starts.length > 0 ? starts.reduce((min, current) => (current < min ? current : min)) : null;
+    const end = ends.length > 0 ? ends.reduce((max, current) => (current > max ? current : max)) : null;
+
+    return { totalCost: total, startDate: start, endDate: end };
+  }, [plan.flights, plan.lineItems]);
+
+  return (
+    <section aria-labelledby="plan-overview-heading">
+      <Card className="flex flex-col gap-6">
+        <header className="flex flex-col gap-2 border-b border-slate-200 pb-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-slate-500">Media Plan</p>
+            <h1 id="plan-overview-heading" className="text-2xl font-semibold text-slate-900 sm:text-3xl">
+              {plan.meta.name}
+            </h1>
+            <p className="mt-1 text-sm text-slate-600">Client: {plan.meta.client}</p>
+          </div>
+          {onEdit ? (
+            <Button variant="secondary" onClick={onEdit} aria-label="Edit plan">
+              Edit plan
+            </Button>
+          ) : null}
+        </header>
+        <dl className="grid grid-cols-1 gap-x-8 gap-y-4 text-sm sm:grid-cols-2 lg:grid-cols-3">
+          <div>
+            <dt className="font-medium text-slate-600">Plan code</dt>
+            <dd className="mt-1 text-slate-900">{plan.meta.code}</dd>
+          </div>
+          <div>
+            <dt className="font-medium text-slate-600">Status</dt>
+            <dd className="mt-1 inline-flex items-center rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-slate-700">
+              {plan.status}
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-slate-600">Total cost</dt>
+            <dd className="mt-1 text-slate-900">{currencyFormatter.format(totalCost)}</dd>
+          </div>
+          <div>
+            <dt className="font-medium text-slate-600">Date range</dt>
+            <dd className="mt-1 text-slate-900">
+              {startDate && endDate ? `${formatDate(startDate)} – ${formatDate(endDate)}` : 'To be scheduled'}
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-slate-600">Owner</dt>
+            <dd className="mt-1 text-slate-900">{plan.owner}</dd>
+          </div>
+          <div>
+            <dt className="font-medium text-slate-600">Approver</dt>
+            <dd className="mt-1 text-slate-900">{plan.approver ?? 'Unassigned'}</dd>
+          </div>
+        </dl>
+      </Card>
+    </section>
+  );
+}

--- a/src/components/PlanCard.tsx
+++ b/src/components/PlanCard.tsx
@@ -1,7 +1,17 @@
 import { Button } from '@/ui/Button';
 import { Card } from '@/ui/Card';
 import type { Plan } from '@/lib/schemas';
-import { formatDate } from '@/lib/date';
+import { formatDate, formatDateRange } from '@/lib/date';
+import { currencyFormatter } from '@/lib/formatters';
+
+function getDateRange(plan: Plan) {
+  if (plan.flights.length === 0) return 'Set flight dates to reveal the schedule';
+  const starts = plan.flights.map((flight) => flight.start_date);
+  const ends = plan.flights.map((flight) => flight.end_date);
+  const minStart = starts.reduce((min, current) => (current < min ? current : min), starts[0]);
+  const maxEnd = ends.reduce((max, current) => (current > max ? current : max), ends[0]);
+  return formatDateRange(minStart, maxEnd);
+}
 
 export function PlanCard({
   plan,
@@ -18,7 +28,12 @@ export function PlanCard({
     <Card className="flex flex-col gap-5">
       <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div className="space-y-2">
-          <h3 className="text-xl font-semibold text-slate-900">{plan.meta.name}</h3>
+          <div className="flex flex-col gap-1">
+            <span className="inline-flex items-center rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700">
+              {plan.meta.client}
+            </span>
+            <h3 className="text-xl font-semibold text-slate-900">{plan.meta.name}</h3>
+          </div>
           <div className="flex flex-wrap items-center gap-2 text-xs font-medium text-slate-500">
             <span className="rounded-full bg-indigo-50 px-2.5 py-1 text-xs font-semibold text-indigo-600">
               v{plan.meta.version}
@@ -28,6 +43,16 @@ export function PlanCard({
             </span>
             <span className="text-slate-400">{plan.meta.code}</span>
           </div>
+          <dl className="grid grid-cols-1 gap-2 text-xs text-slate-500 sm:grid-cols-2">
+            <div>
+              <dt className="uppercase tracking-wide">Plan window</dt>
+              <dd className="text-sm font-medium text-slate-800">{getDateRange(plan)}</dd>
+            </div>
+            <div>
+              <dt className="uppercase tracking-wide">Working budget</dt>
+              <dd className="text-sm font-medium text-slate-800">{currencyFormatter.format(plan.goal.budget)}</dd>
+            </div>
+          </dl>
         </div>
         <span className="inline-flex items-center rounded-full bg-slate-50 px-3 py-1 text-xs font-medium text-slate-500">
           Updated {formatDate(plan.lastModified)}

--- a/src/components/PlanList.tsx
+++ b/src/components/PlanList.tsx
@@ -1,7 +1,31 @@
 import type { Plan } from '@/lib/schemas';
 import { PlanCard } from './PlanCard';
+import { Table, THead, TBody, Th, Td } from '@/ui/Table';
+import { currencyFormatter } from '@/lib/formatters';
+import { formatDate, formatDateRange } from '@/lib/date';
+import { Button } from '@/ui/Button';
 
-export function PlanList({
+export type PlanListView = 'grid' | 'list';
+
+function getPlanDateRange(plan: Plan) {
+  if (plan.flights.length === 0) return 'Not scheduled';
+  const starts = plan.flights.map((flight) => flight.start_date);
+  const ends = plan.flights.map((flight) => flight.end_date);
+  const minStart = starts.reduce((min, current) => (current < min ? current : min), starts[0]);
+  const maxEnd = ends.reduce((max, current) => (current > max ? current : max), ends[0]);
+  return formatDateRange(minStart, maxEnd);
+}
+
+function getCreatedEvent(plan: Plan) {
+  const created = plan.audit.find((event) => event.action === 'created');
+  return created ?? plan.audit[0];
+}
+
+function getLastEvent(plan: Plan) {
+  return plan.audit[plan.audit.length - 1];
+}
+
+function GridView({
   plans,
   onOpen,
   onReview,
@@ -12,10 +36,6 @@ export function PlanList({
   onReview: (id: string) => void;
   onDuplicate: (id: string) => void;
 }) {
-  if (plans.length === 0) {
-    return <p className="text-sm text-slate-500">No plans yet. Create one to get started.</p>;
-  }
-
   return (
     <div className="grid grid-cols-1 gap-5 sm:gap-6 md:grid-cols-2">
       {plans.map((plan) => (
@@ -29,4 +49,103 @@ export function PlanList({
       ))}
     </div>
   );
+}
+
+function ListView({
+  plans,
+  onOpen,
+  onReview,
+  onDuplicate,
+}: {
+  plans: Plan[];
+  onOpen: (id: string) => void;
+  onReview: (id: string) => void;
+  onDuplicate: (id: string) => void;
+}) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+      <Table>
+        <THead>
+          <tr>
+            <Th align="left">Plan</Th>
+            <Th align="left">Client</Th>
+            <Th align="left">Date range</Th>
+            <Th align="right">Budget</Th>
+            <Th align="left">Status</Th>
+            <Th align="left">Created</Th>
+            <Th align="left">Updated</Th>
+            <Th align="left">Owner</Th>
+            <Th align="left">Updated by</Th>
+            <Th align="right">Actions</Th>
+          </tr>
+        </THead>
+        <TBody>
+          {plans.map((plan) => {
+            const created = getCreatedEvent(plan);
+            const lastEvent = getLastEvent(plan) ?? created;
+            return (
+              <tr key={plan.id} className="bg-white hover:bg-slate-50">
+                <Td>{plan.meta.name}</Td>
+                <Td>{plan.meta.client}</Td>
+                <Td>{getPlanDateRange(plan)}</Td>
+                <Td align="right">{currencyFormatter.format(plan.goal.budget)}</Td>
+                <Td>{plan.status}</Td>
+                <Td>
+                  <div className="flex flex-col">
+                    <span className="text-sm font-medium text-slate-800">{formatDate(created?.timestamp ?? plan.lastModified)}</span>
+                    <span className="text-xs text-slate-500">{created?.actor ?? plan.owner}</span>
+                  </div>
+                </Td>
+                <Td>
+                  <div className="flex flex-col">
+                    <span className="text-sm font-medium text-slate-800">{formatDate(plan.lastModified)}</span>
+                    <span className="text-xs text-slate-500">{lastEvent?.actor ?? plan.owner}</span>
+                  </div>
+                </Td>
+                <Td>{plan.owner}</Td>
+                <Td>{lastEvent?.actor ?? plan.owner}</Td>
+                <Td align="right">
+                  <div className="flex flex-col gap-1 sm:flex-row sm:justify-end">
+                    <Button className="px-3 py-1 text-xs" onClick={() => onOpen(plan.id)}>
+                      Open
+                    </Button>
+                    <Button className="px-3 py-1 text-xs" variant="secondary" onClick={() => onReview(plan.id)}>
+                      Review
+                    </Button>
+                    <Button className="px-3 py-1 text-xs" variant="ghost" onClick={() => onDuplicate(plan.id)}>
+                      Duplicate
+                    </Button>
+                  </div>
+                </Td>
+              </tr>
+            );
+          })}
+        </TBody>
+      </Table>
+    </div>
+  );
+}
+
+export function PlanList({
+  plans,
+  viewMode = 'grid',
+  onOpen,
+  onReview,
+  onDuplicate,
+}: {
+  plans: Plan[];
+  viewMode?: PlanListView;
+  onOpen: (id: string) => void;
+  onReview: (id: string) => void;
+  onDuplicate: (id: string) => void;
+}) {
+  if (plans.length === 0) {
+    return <p className="text-sm text-slate-500">No plans yet. Create one to get started.</p>;
+  }
+
+  if (viewMode === 'list') {
+    return <ListView plans={plans} onOpen={onOpen} onReview={onReview} onDuplicate={onDuplicate} />;
+  }
+
+  return <GridView plans={plans} onOpen={onOpen} onReview={onReview} onDuplicate={onDuplicate} />;
 }

--- a/src/components/PlanTitleBar.tsx
+++ b/src/components/PlanTitleBar.tsx
@@ -7,9 +7,11 @@ import { Input } from '@/ui/Input';
 import { Button } from '@/ui/Button';
 import { useMutatePlan } from '@/api/plans';
 import { useUser, canApprove } from '@/auth/useUser';
+import { formatDateTime } from '@/lib/date';
 
 const metaSchema = z.object({
   name: z.string().min(2, 'Name is required'),
+  client: z.string().min(2, 'Client is required'),
   code: z.string().min(1, 'Code is required'),
 });
 
@@ -37,12 +39,12 @@ export function PlanTitleBar({
 
   const form = useForm<MetaForm>({
     resolver: zodResolver(metaSchema),
-    defaultValues: { name: plan.meta.name, code: plan.meta.code },
+    defaultValues: { name: plan.meta.name, client: plan.meta.client, code: plan.meta.code },
   });
 
   useEffect(() => {
-    form.reset({ name: plan.meta.name, code: plan.meta.code });
-  }, [plan.meta.name, plan.meta.code, form]);
+    form.reset({ name: plan.meta.name, client: plan.meta.client, code: plan.meta.code });
+  }, [plan.meta.name, plan.meta.client, plan.meta.code, form]);
 
   const submitMeta = form.handleSubmit(async (values) => {
     if (editingDisabled) return;
@@ -59,12 +61,18 @@ export function PlanTitleBar({
   const showRevert = plan.status !== 'Draft' && plan.status !== 'Approved';
 
   const nameId = `plan-name-${plan.id}`;
+  const clientId = `plan-client-${plan.id}`;
   const codeId = `plan-code-${plan.id}`;
 
   return (
     <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
       <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
         <div className="flex w-full flex-col gap-4 lg:max-w-xl">
+          <div className="rounded-lg border border-indigo-200 bg-indigo-50 px-4 py-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600">Client</p>
+            <p className="text-lg font-semibold text-indigo-900">{plan.meta.client}</p>
+            <p className="text-xs text-indigo-700">Keep teams aligned by validating the brand you are planning for.</p>
+          </div>
           <form
             className="grid w-full gap-4 sm:grid-cols-3 sm:items-end"
             onSubmit={(event) => event.preventDefault()}
@@ -76,6 +84,18 @@ export function PlanTitleBar({
               <Input
                 {...form.register('name')}
                 id={nameId}
+                onBlur={() => submitMeta()}
+                disabled={editingDisabled}
+                className="w-full"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label htmlFor={clientId} className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                Client
+              </label>
+              <Input
+                {...form.register('client')}
+                id={clientId}
                 onBlur={() => submitMeta()}
                 disabled={editingDisabled}
                 className="w-full"
@@ -99,7 +119,7 @@ export function PlanTitleBar({
               v{plan.meta.version}
             </span>
             <span className="rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-600">{plan.status}</span>
-            <span className="text-slate-400">Last modified {new Date(plan.lastModified).toLocaleString()}</span>
+            <span className="text-slate-400">Last modified {formatDateTime(plan.lastModified)}</span>
           </div>
           <p className="text-xs text-slate-500">Autosaves instantly after each change.</p>
         </div>

--- a/src/components/dialogs/AddChannelDialog.tsx
+++ b/src/components/dialogs/AddChannelDialog.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { Modal } from '@/ui/Modal';
+import { Button } from '@/ui/Button';
+import { Select } from '@/ui/Select';
+import { channelEnum, type Channel } from '@/lib/schemas';
+
+export function AddChannelDialog({
+  open,
+  busy,
+  onClose,
+  onAdd,
+}: {
+  open: boolean;
+  busy: boolean;
+  onClose: () => void;
+  onAdd: (channel: Channel) => Promise<void> | void;
+}) {
+  const [selected, setSelected] = useState<Channel>(channelEnum.options[0]);
+
+  useEffect(() => {
+    if (open) {
+      setSelected(channelEnum.options[0]);
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title="Add a channel"
+      description="Create a new channel row and scaffold the required flighting details."
+      footer={
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            disabled={busy}
+            onClick={() => {
+              void onAdd(selected);
+            }}
+          >
+            Add channel
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-4">
+        <p className="text-sm text-slate-600">
+          Channels determine the fields shown in the line item form and the columns rendered in the flighting table.
+        </p>
+        <label className="flex flex-col gap-2 text-sm text-slate-700">
+          <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">Channel</span>
+          <Select value={selected} onChange={(event) => setSelected(event.currentTarget.value as Channel)}>
+            {channelEnum.options.map((channel) => (
+              <option key={channel} value={channel}>
+                {channel.replace(/_/g, ' ')}
+              </option>
+            ))}
+          </Select>
+        </label>
+        <p className="text-xs text-slate-500">
+          Channel-specific extension fields will be pre-filled with placeholder values so planners can refine them later.
+        </p>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/dialogs/FlightingScheduleDialog.tsx
+++ b/src/components/dialogs/FlightingScheduleDialog.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { ChannelFlighting } from '@/api/plans';
+import { Modal } from '@/ui/Modal';
+import { Button } from '@/ui/Button';
+import { addDays, enumerateWeeks, formatDateRange, toIsoDate } from '@/lib/date';
+
+export function FlightingScheduleDialog({
+  flighting,
+  open,
+  onClose,
+  onSave,
+}: {
+  flighting: ChannelFlighting | null;
+  open: boolean;
+  onClose: () => void;
+  onSave: (flightId: string, periods: { start: string; end: string }[]) => Promise<void> | void;
+}) {
+  const flight = flighting?.flight;
+  const [selectedWeeks, setSelectedWeeks] = useState<Set<string>>(new Set());
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!open || !flight) return;
+    const initial = new Set<string>();
+    const basePeriods =
+      flight.active_periods_json && flight.active_periods_json.length > 0
+        ? flight.active_periods_json
+        : [{ start: flight.start_date, end: flight.end_date }];
+    for (const period of basePeriods) {
+      const weeks = enumerateWeeks(new Date(period.start), new Date(period.end));
+      weeks.forEach((week) => initial.add(week.key));
+    }
+    setSelectedWeeks(initial);
+  }, [flight, open]);
+
+  const weeks = useMemo(() => {
+    if (!flight) return [] as ReturnType<typeof enumerateWeeks>;
+    return enumerateWeeks(new Date(flight.start_date), new Date(flight.end_date));
+  }, [flight]);
+
+  if (!open || !flighting || !flight) {
+    return null;
+  }
+
+  const handleToggle = (weekKey: string) => {
+    setSelectedWeeks((prev) => {
+      const next = new Set(prev);
+      if (next.has(weekKey)) {
+        next.delete(weekKey);
+      } else {
+        next.add(weekKey);
+      }
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    if (selectedWeeks.size === 0) return;
+    setSaving(true);
+    const periods = derivePeriods(weeks, selectedWeeks, flight.start_date, flight.end_date);
+    try {
+      await onSave(flight.flight_id, periods);
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const vendorName = flighting.vendor?.name ?? 'Flighting';
+  const channelName = flighting.lineItem.channel.replace(/_/g, ' ');
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={`Schedule ${vendorName}`}
+      description={`Select the weeks ${channelName} should be in market. Unselected weeks will be treated as a dark period.`}
+      footer={
+        <div className="flex justify-between gap-2">
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button disabled={saving || selectedWeeks.size === 0} onClick={handleSave}>
+            Save schedule
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-3">
+        <p className="text-sm text-slate-600">
+          Toggle weeks to reflect pulsing or hiatus periods. Flight start and end dates remain unchanged.
+        </p>
+        <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {weeks.map((week) => {
+            const weekStart = new Date(Math.max(week.start.getTime(), new Date(flight.start_date).getTime()));
+            const weekEnd = new Date(Math.min(week.end.getTime(), new Date(flight.end_date).getTime()));
+            const label = formatDateRange(toIsoDate(weekStart), toIsoDate(weekEnd));
+            const checked = selectedWeeks.has(week.key);
+            return (
+              <li key={week.key}>
+                <label className="flex cursor-pointer items-center gap-3 rounded-lg border border-slate-200 bg-white px-3 py-2 shadow-sm transition hover:border-indigo-400">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                    checked={checked}
+                    onChange={() => handleToggle(week.key)}
+                  />
+                  <span className="text-sm font-medium text-slate-700">{label}</span>
+                </label>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </Modal>
+  );
+}
+
+function derivePeriods(
+  weeks: ReturnType<typeof enumerateWeeks>,
+  selection: Set<string>,
+  flightStart: string,
+  flightEnd: string,
+) {
+  const activeWeeks = weeks
+    .filter((week) => selection.has(week.key))
+    .sort((a, b) => a.start.getTime() - b.start.getTime());
+
+  const periods: { start: string; end: string }[] = [];
+  if (activeWeeks.length === 0) return periods;
+
+  let currentStart = new Date(activeWeeks[0].start);
+  let currentEnd = new Date(activeWeeks[0].end);
+
+  for (let index = 1; index < activeWeeks.length; index += 1) {
+    const week = activeWeeks[index];
+    const previousEndPlusOne = addDays(currentEnd, 1);
+    if (week.start.getTime() <= previousEndPlusOne.getTime()) {
+      currentEnd = new Date(week.end);
+    } else {
+      periods.push({
+        start: toIsoDate(clampDate(currentStart, new Date(flightStart), new Date(flightEnd))),
+        end: toIsoDate(clampDate(currentEnd, new Date(flightStart), new Date(flightEnd))),
+      });
+      currentStart = new Date(week.start);
+      currentEnd = new Date(week.end);
+    }
+  }
+
+  periods.push({
+    start: toIsoDate(clampDate(currentStart, new Date(flightStart), new Date(flightEnd))),
+    end: toIsoDate(clampDate(currentEnd, new Date(flightStart), new Date(flightEnd))),
+  });
+
+  return periods;
+}
+
+function clampDate(value: Date, min: Date, max: Date) {
+  return new Date(Math.min(Math.max(value.getTime(), min.getTime()), max.getTime()));
+}

--- a/src/data/seed.ts
+++ b/src/data/seed.ts
@@ -936,7 +936,12 @@ const deliveryActuals = lineItems.flatMap((item, index) =>
 export const plans = [
   planSchema.parse({
     id: 'plan-aurora-fy25',
-    meta: { name: 'Aurora Sparkling FY25 Launch', code: 'AURORA-FY25', version: 1 },
+    meta: {
+      name: 'Aurora Sparkling FY25 Launch',
+      client: 'Aurora Beverages',
+      code: 'AURORA-FY25',
+      version: 1,
+    },
     status: 'Draft',
     goal: { budget: 1_200_000, reach: 6_200_000, frequency: 3.2 },
     campaigns,

--- a/src/lib/channelExtensions.ts
+++ b/src/lib/channelExtensions.ts
@@ -1,0 +1,33 @@
+import type { Channel, LineItem } from './schemas';
+
+type ExtensionKey = Extract<keyof LineItem, `${string}_ext`>;
+
+export const extensionKeyByChannel: Partial<Record<Channel, ExtensionKey>> = {
+  OOH: 'ooh_ext',
+  TV: 'tv_ext',
+  BVOD_CTV: 'bvod_ext',
+  Digital_Display: 'digital_ext',
+  Digital_Video: 'digital_ext',
+  Social: 'social_ext',
+  Search: 'search_ext',
+  Radio: 'audio_ext',
+  Streaming_Audio: 'audio_ext',
+  Podcast: 'podcast_ext',
+  Cinema: 'cinema_ext',
+  Print: 'print_ext',
+  Retail_Media: 'retail_media_ext',
+  Influencer: 'influencer_ext',
+  Sponsorship: 'sponsorship_ext',
+  Email: 'email_dm_ext',
+  Direct_Mail: 'email_dm_ext',
+  Gaming: 'gaming_native_ext',
+  Native: 'gaming_native_ext',
+  Affiliate: 'affiliate_ext',
+  Experiential: 'sponsorship_ext',
+};
+
+export function getChannelExtension(lineItem: LineItem) {
+  const key = extensionKeyByChannel[lineItem.channel];
+  if (!key) return undefined;
+  return lineItem[key];
+}

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,9 +1,58 @@
+const LOCALE = 'en-AU';
+
 export function formatDate(value: string | Date) {
   const date = typeof value === 'string' ? new Date(value) : value;
-  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(date);
+  return new Intl.DateTimeFormat(LOCALE, { dateStyle: 'medium' }).format(date);
+}
+
+export function formatDateTime(value: string | Date) {
+  const date = typeof value === 'string' ? new Date(value) : value;
+  return new Intl.DateTimeFormat(LOCALE, { dateStyle: 'medium', timeStyle: 'short' }).format(date);
 }
 
 export function formatDateRange(start: string, end: string) {
-  const formatter = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' });
+  const formatter = new Intl.DateTimeFormat(LOCALE, { month: 'short', day: 'numeric' });
   return `${formatter.format(new Date(start))} – ${formatter.format(new Date(end))}`;
+}
+
+export function startOfWeekSunday(input: Date) {
+  const date = new Date(input);
+  date.setHours(0, 0, 0, 0);
+  const day = date.getDay();
+  const diff = day === 0 ? 0 : day;
+  date.setDate(date.getDate() - diff);
+  return date;
+}
+
+export function endOfWeekSaturday(input: Date) {
+  const start = startOfWeekSunday(input);
+  start.setDate(start.getDate() + 6);
+  return start;
+}
+
+export function addDays(input: Date, amount: number) {
+  const date = new Date(input);
+  date.setDate(date.getDate() + amount);
+  return date;
+}
+
+export function toIsoDate(input: Date) {
+  const copy = new Date(input);
+  copy.setHours(0, 0, 0, 0);
+  const offsetMinutes = copy.getTimezoneOffset();
+  const adjusted = new Date(copy.getTime() - offsetMinutes * 60 * 1000);
+  return adjusted.toISOString().slice(0, 10);
+}
+
+export function enumerateWeeks(start: Date, end: Date) {
+  const weeks: { start: Date; end: Date; key: string }[] = [];
+  let cursor = startOfWeekSunday(start);
+  const limit = startOfWeekSunday(end);
+  while (cursor.getTime() <= limit.getTime()) {
+    const weekStart = new Date(cursor);
+    const weekEnd = endOfWeekSaturday(weekStart);
+    weeks.push({ start: weekStart, end: weekEnd, key: toIsoDate(weekStart) });
+    cursor = addDays(cursor, 7);
+  }
+  return weeks;
 }

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -1,14 +1,16 @@
-export const currencyFormatter = new Intl.NumberFormat(undefined, {
+const LOCALE = 'en-AU';
+
+export const currencyFormatter = new Intl.NumberFormat(LOCALE, {
   style: 'currency',
-  currency: 'USD',
+  currency: 'AUD',
   maximumFractionDigits: 0,
 });
 
-export const percentFormatter = new Intl.NumberFormat(undefined, {
+export const percentFormatter = new Intl.NumberFormat(LOCALE, {
   style: 'percent',
   maximumFractionDigits: 1,
 });
 
-export const numberFormatter = new Intl.NumberFormat(undefined, {
+export const numberFormatter = new Intl.NumberFormat(LOCALE, {
   maximumFractionDigits: 0,
 });

--- a/src/lib/planBuilders.ts
+++ b/src/lib/planBuilders.ts
@@ -1,0 +1,278 @@
+import {
+  campaignSchema,
+  audienceSchema,
+  vendorSchema,
+  creativeSchema,
+  flightSchema,
+  lineItemSchema,
+  trackingSchema,
+  planSchema,
+  type Plan,
+  type Channel,
+} from '@/lib/schemas';
+import { createId } from '@/lib/id';
+import { addDays, startOfWeekSunday, toIsoDate } from '@/lib/date';
+
+const channelCreativeFormat: Partial<Record<Channel, string>> = {
+  TV: 'Video',
+  BVOD_CTV: 'Connected TV',
+  Digital_Display: 'Display',
+  Digital_Video: 'Video',
+  Social: 'Social',
+  Search: 'Search',
+  Radio: 'Audio',
+  Streaming_Audio: 'Audio',
+  Podcast: 'Podcast',
+  Cinema: 'Cinema',
+  Print: 'Print',
+  Retail_Media: 'Retail',
+  Influencer: 'Influencer',
+  Sponsorship: 'Sponsorship',
+  Email: 'Email',
+  Direct_Mail: 'Direct Mail',
+  Gaming: 'Gaming',
+  Native: 'Native',
+  Affiliate: 'Affiliate',
+  Experiential: 'Experiential',
+  OOH: 'OOH',
+};
+
+function defaultCampaign(plan: Plan) {
+  if (plan.campaigns.length > 0) {
+    return plan.campaigns[0];
+  }
+
+  return campaignSchema.parse({
+    campaign_id: createId('cmp'),
+    brand: plan.meta.client,
+    market: 'Australia',
+    objective: 'Define campaign objective',
+    primary_kpi: 'Reach',
+    fiscal_period: 'FY25',
+  });
+}
+
+function defaultAudience() {
+  return audienceSchema.parse({
+    audience_id: createId('aud'),
+    definition: 'Audience pending definition',
+    segments_json: [],
+  });
+}
+
+function defaultVendor() {
+  return vendorSchema.parse({
+    vendor_id: createId('vnd'),
+    name: 'Pending vendor',
+  });
+}
+
+function defaultCreative(channel: Channel) {
+  return creativeSchema.parse({
+    creative_id: createId('crv'),
+    ad_name: `${channel.replace(/_/g, ' ')} placeholder`,
+    asset_uri: 'https://example.com/assets/placeholder',
+    format: channelCreativeFormat[channel] ?? 'Standard',
+  });
+}
+
+function defaultLineItemExtension(channel: Channel) {
+  switch (channel) {
+    case 'OOH':
+      return {
+        ooh_ext: {
+          ooh_asset_id: createId('ooh'),
+          owner: 'Pending owner',
+          format: 'Large format digital',
+          digital: true,
+          address: '1 Example Way',
+          suburb: 'Sydney',
+          state: 'NSW',
+          postcode: '2000',
+          lat: -33.8688,
+          long: 151.2093,
+        },
+      } as const;
+    case 'TV':
+      return {
+        tv_ext: {
+          network: 'TBD Network',
+          spot_length_sec: 30,
+          spot_count: 10,
+          buy_unit: 'spot',
+        },
+      } as const;
+    case 'BVOD_CTV':
+      return {
+        bvod_ext: {
+          platform: '9Now',
+        },
+      } as const;
+    case 'Digital_Display':
+    case 'Digital_Video':
+      return {
+        digital_ext: {
+          inventory_type: 'display',
+        },
+      } as const;
+    case 'Social':
+      return {
+        social_ext: {
+          platform: 'Meta',
+          objective: 'Awareness',
+        },
+      } as const;
+    case 'Search':
+      return {
+        search_ext: {
+          engine: 'Google',
+          campaign_type: 'Search',
+          ad_group: 'New Ad Group',
+        },
+      } as const;
+    case 'Radio':
+    case 'Streaming_Audio':
+      return {
+        audio_ext: {
+          network_or_platform: 'Network TBD',
+          spot_len_sec: 30,
+          spots: 10,
+        },
+      } as const;
+    case 'Podcast':
+      return {
+        podcast_ext: {
+          publisher: 'Podcast Network',
+          show: 'Flagship Show',
+        },
+      } as const;
+    case 'Cinema':
+      return {
+        cinema_ext: {
+          circuit: 'Hoyts',
+          spot_len_sec: 30,
+        },
+      } as const;
+    case 'Print':
+      return {
+        print_ext: {
+          publication: 'Trade Publication',
+          edition_date: toIsoDate(new Date()),
+        },
+      } as const;
+    case 'Retail_Media':
+      return {
+        retail_media_ext: {
+          retailer: 'Cartology',
+        },
+      } as const;
+    case 'Influencer':
+      return {
+        influencer_ext: {
+          creator_handle: '@creator',
+          platform: 'Instagram',
+        },
+      } as const;
+    case 'Sponsorship':
+    case 'Experiential':
+      return {
+        sponsorship_ext: {
+          property: 'Sponsorship Property',
+        },
+      } as const;
+    case 'Email':
+      return {
+        email_dm_ext: {
+          channel_type: 'email',
+          list_source: 'First-party CRM',
+        },
+      } as const;
+    case 'Direct_Mail':
+      return {
+        email_dm_ext: {
+          channel_type: 'direct_mail',
+          list_source: 'Mailhouse partner',
+        },
+      } as const;
+    case 'Gaming':
+      return {
+        gaming_native_ext: {
+          subtype: 'gaming',
+          title_or_publisher: 'Gaming Partner',
+        },
+      } as const;
+    case 'Native':
+      return {
+        gaming_native_ext: {
+          subtype: 'native',
+          title_or_publisher: 'Native Partner',
+        },
+      } as const;
+    case 'Affiliate':
+      return {
+        affiliate_ext: {
+          network: 'Affiliate Network',
+          partner_id: createId('partner'),
+          commission_model: 'CPS',
+        },
+      } as const;
+    default:
+      return {} as const;
+  }
+}
+
+export function addChannelDraft(plan: Plan, channel: Channel): Plan {
+  const campaign = defaultCampaign(plan);
+  const audience = defaultAudience();
+  const vendor = defaultVendor();
+  const creative = defaultCreative(channel);
+
+  const now = new Date();
+  const start = startOfWeekSunday(now);
+  const end = addDays(start, 27);
+
+  const flight = flightSchema.parse({
+    flight_id: createId('flt'),
+    campaign_id: campaign.campaign_id,
+    start_date: toIsoDate(start),
+    end_date: toIsoDate(end),
+    budget_total: 0,
+    buy_type: 'Guaranteed',
+    buying_currency: 'AUD',
+    fx_rate: 1,
+  });
+
+  const lineItem = lineItemSchema.parse({
+    line_item_id: createId('li'),
+    flight_id: flight.flight_id,
+    audience_id: audience.audience_id,
+    vendor_id: vendor.vendor_id,
+    creative_id: creative.creative_id,
+    channel,
+    goal_type: 'Impressions',
+    pricing_model: 'CPM',
+    rate_numeric: 10,
+    rate_unit: 'CPM',
+    units_planned: 0,
+    cost_planned: 0,
+    pacing: 'Even',
+    ...defaultLineItemExtension(channel),
+  });
+
+  const tracking = trackingSchema.parse({
+    line_item_id: lineItem.line_item_id,
+  });
+
+  const campaigns = plan.campaigns.length > 0 ? [...plan.campaigns] : [...plan.campaigns, campaign];
+
+  return planSchema.parse({
+    ...plan,
+    campaigns,
+    flights: [...plan.flights, flight],
+    audiences: [...plan.audiences, audience],
+    vendors: [...plan.vendors, vendor],
+    creatives: [...plan.creatives, creative],
+    lineItems: [...plan.lineItems, lineItem],
+    tracking: [...plan.tracking, tracking],
+  });
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,7 +1,8 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { usePlans, useCreatePlan, useDuplicatePlan } from '@/api/plans';
 import { Button } from '@/ui/Button';
-import { PlanList } from '@/components/PlanList';
+import { PlanList, type PlanListView } from '@/components/PlanList';
 import { useUser } from '@/auth/useUser';
 
 export function DashboardPage() {
@@ -10,6 +11,7 @@ export function DashboardPage() {
   const createPlan = useCreatePlan();
   const duplicatePlan = useDuplicatePlan();
   const { user } = useUser();
+  const [viewMode, setViewMode] = useState<PlanListView>('grid');
 
   const handleCreate = async () => {
     const plan = await createPlan.mutateAsync();
@@ -30,18 +32,37 @@ export function DashboardPage() {
               Manage media plans, versions, and approvals from one place.
             </p>
           </div>
-          <Button
-            onClick={handleCreate}
-            disabled={createPlan.isPending}
-            className="self-start sm:self-auto"
-          >
-            New Plan
-          </Button>
+          <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
+            <div className="inline-flex rounded-md border border-slate-200 bg-white p-1 text-xs font-medium text-slate-600 shadow-sm">
+              <button
+                type="button"
+                onClick={() => setViewMode('grid')}
+                className={`rounded px-3 py-1 transition ${viewMode === 'grid' ? 'bg-indigo-100 text-indigo-700' : 'hover:bg-slate-100'}`}
+              >
+                Card view
+              </button>
+              <button
+                type="button"
+                onClick={() => setViewMode('list')}
+                className={`rounded px-3 py-1 transition ${viewMode === 'list' ? 'bg-indigo-100 text-indigo-700' : 'hover:bg-slate-100'}`}
+              >
+                List view
+              </button>
+            </div>
+            <Button
+              onClick={handleCreate}
+              disabled={createPlan.isPending}
+              className="self-start sm:self-auto"
+            >
+              New Plan
+            </Button>
+          </div>
         </header>
         {isLoading ? <p className="text-sm text-slate-500">Loading plans...</p> : null}
         {!isLoading ? (
           <PlanList
             plans={plans}
+            viewMode={viewMode}
             onOpen={(id) => navigate(`/plan/${id}`)}
             onReview={(id) => navigate(`/plan/${id}/review`)}
             onDuplicate={handleDuplicate}

--- a/src/pages/MediaPlanningPage.tsx
+++ b/src/pages/MediaPlanningPage.tsx
@@ -1,8 +1,7 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
   usePlan,
-  useMutatePlan,
   useSubmitPlan,
   useApprovePlan,
   useRejectPlan,
@@ -11,8 +10,6 @@ import {
 } from '@/api/plans';
 import { GoalKPIBar } from '@/components/GoalKPIBar';
 import { ChannelTable } from '@/components/ChannelTable';
-import { BudgetAllocator } from '@/components/BudgetAllocator';
-import { SummarySidebar } from '@/components/SummarySidebar';
 import { PacingWarnings } from '@/components/PacingWarnings';
 import { PlanTitleBar } from '@/components/PlanTitleBar';
 import { AuditDrawer } from '@/components/AuditDrawer';
@@ -20,12 +17,12 @@ import { ExportDialog } from '@/components/ExportDialog';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { Button } from '@/ui/Button';
 import { useUser } from '@/auth/useUser';
+import { MediaPlanOverviewCard } from '@/components/MediaPlanOverviewCard';
 
 export function MediaPlanningPage() {
   const params = useParams();
   const navigate = useNavigate();
   const { data: plan, isLoading } = usePlan(params.id);
-  const mutatePlan = useMutatePlan();
   const submitPlan = useSubmitPlan();
   const approvePlan = useApprovePlan();
   const rejectPlan = useRejectPlan();
@@ -41,6 +38,15 @@ export function MediaPlanningPage() {
 
   const pageTitle = useMemo(() => plan?.meta.name ?? 'Plan', [plan?.meta.name]);
 
+  const handleOverviewEdit = useCallback(() => {
+    if (typeof window === 'undefined' || !plan?.id) return;
+    const target = document.getElementById(`plan-name-${plan.id}`);
+    if (!(target instanceof HTMLElement)) return;
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    target.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', block: 'center' });
+    target.focus();
+  }, [plan?.id]);
+
   if (isLoading) {
     return <p className="text-sm text-slate-500">Loading plan...</p>;
   }
@@ -53,17 +59,6 @@ export function MediaPlanningPage() {
       </div>
     );
   }
-
-  const handleBudgetChange = (lineItemId: string, budget: number) => {
-    if (editingDisabled) return;
-    const next = {
-      ...plan,
-      lineItems: plan.lineItems.map((item) =>
-        item.line_item_id === lineItemId ? { ...item, cost_planned: budget } : item,
-      ),
-    };
-    mutatePlan.mutate(next);
-  };
 
   const handleSubmit = async () => {
     await submitPlan.mutateAsync({ id: plan.id, actor: user.name });
@@ -113,6 +108,7 @@ export function MediaPlanningPage() {
             Export Block Plan
           </Button>
         </header>
+        <MediaPlanOverviewCard plan={plan} onEdit={handleOverviewEdit} />
         <PlanTitleBar
           plan={plan}
           editingDisabled={Boolean(editingDisabled)}
@@ -122,19 +118,16 @@ export function MediaPlanningPage() {
           onRevert={handleRevert}
           onDuplicate={handleDuplicate}
         />
-        <GoalKPIBar plan={plan} />
-        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-          <div className="space-y-6 lg:col-span-2">
-            <ChannelTable plan={plan} readOnly={editingDisabled} />
-            <BudgetAllocator
-              plan={plan}
-              onBudgetChange={handleBudgetChange}
-              readOnly={editingDisabled}
-            />
-            <PacingWarnings plan={plan} />
-            <AuditDrawer events={plan.audit} />
-          </div>
-          <SummarySidebar plan={plan} />
+        <section aria-labelledby="plan-health" className="space-y-4">
+          <h2 id="plan-health" className="sr-only">
+            Plan health
+          </h2>
+          <GoalKPIBar plan={plan} />
+        </section>
+        <ChannelTable plan={plan} readOnly={editingDisabled} />
+        <div className="space-y-6">
+          <PacingWarnings plan={plan} />
+          <AuditDrawer events={plan.audit} />
         </div>
         <ExportDialog plan={plan} open={exportOpen} onClose={() => setExportOpen(false)} />
         <ConfirmDialog

--- a/src/pages/PlanDetailPage.tsx
+++ b/src/pages/PlanDetailPage.tsx
@@ -3,7 +3,6 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { usePlan, useApprovePlan, useRejectPlan, useRevertPlan } from '@/api/plans';
 import { GoalKPIBar } from '@/components/GoalKPIBar';
 import { ChannelTable } from '@/components/ChannelTable';
-import { SummarySidebar } from '@/components/SummarySidebar';
 import { PacingWarnings } from '@/components/PacingWarnings';
 import { AuditDrawer } from '@/components/AuditDrawer';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
@@ -59,13 +58,10 @@ export function PlanDetailPage() {
         </Button>
       </div>
       <GoalKPIBar plan={plan} />
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[2fr,1fr]">
-        <div className="space-y-4">
-          <ChannelTable plan={plan} readOnly />
-          <PacingWarnings plan={plan} />
-          <AuditDrawer events={plan.audit} />
-        </div>
-        <SummarySidebar plan={plan} />
+      <div className="space-y-4">
+        <ChannelTable plan={plan} readOnly />
+        <PacingWarnings plan={plan} />
+        <AuditDrawer events={plan.audit} />
       </div>
       {canApprove(user) ? (
         <div className="flex flex-wrap gap-2">

--- a/src/tests/ChannelTable.test.tsx
+++ b/src/tests/ChannelTable.test.tsx
@@ -1,0 +1,108 @@
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, within, waitFor, fireEvent } from '@testing-library/react';
+import { ChannelTable } from '@/components/ChannelTable';
+import { plans } from '@/data/seed';
+import type { Channel } from '@/lib/schemas';
+import type { ChannelFlighting } from '@/api/plans';
+
+const plan = plans[0];
+
+const mockUseChannelFlightings = vi.fn();
+const mockMutatePlan = { mutateAsync: vi.fn(), isPending: false };
+
+vi.mock('@/api/plans', async () => {
+  const actual = await vi.importActual<typeof import('@/api/plans')>('@/api/plans');
+  return {
+    ...actual,
+    useChannelFlightings: (planId: string | undefined, channel: Channel) =>
+      mockUseChannelFlightings(planId, channel),
+    useMutatePlan: () => mockMutatePlan,
+  };
+});
+
+describe('ChannelTable', () => {
+  beforeEach(() => {
+    mockUseChannelFlightings.mockImplementation((planId: string | undefined, channel: Channel) => {
+      const rows: ChannelFlighting[] = plan.lineItems
+        .filter((item) => item.channel === channel)
+        .map((lineItem) => ({
+          lineItem,
+          flight: plan.flights.find((flight) => flight.flight_id === lineItem.flight_id),
+          vendor: plan.vendors.find((vendor) => vendor.vendor_id === lineItem.vendor_id),
+          audience: plan.audiences.find((audience) => audience.audience_id === lineItem.audience_id),
+          creative: plan.creatives.find((creative) => creative.creative_id === lineItem.creative_id),
+          tracking: plan.tracking.find((tracking) => tracking.line_item_id === lineItem.line_item_id),
+        }));
+
+      return {
+        data: rows,
+        isLoading: false,
+        isError: false,
+        isRefetching: false,
+        refetch: vi.fn(),
+      };
+    });
+  });
+
+  afterEach(() => {
+    mockUseChannelFlightings.mockClear();
+    mockMutatePlan.mutateAsync.mockClear();
+  });
+
+  it('renders a summary row for each channel', () => {
+    render(<ChannelTable plan={plan} readOnly />);
+    const uniqueChannels = new Set(plan.lineItems.map((item) => item.channel));
+    const dropdowns = screen.getAllByRole('combobox');
+    expect(dropdowns).toHaveLength(uniqueChannels.size);
+  });
+
+  it('updates sorting state for the cost column', () => {
+    render(<ChannelTable plan={plan} readOnly />);
+    const costHeader = screen.getAllByRole('columnheader', { name: /cost/i })[0];
+    expect(costHeader).toHaveAttribute('aria-sort', 'none');
+    const sortButton = within(costHeader).getByRole('button', { name: /cost/i });
+    fireEvent.click(sortButton);
+    expect(costHeader).toHaveAttribute('aria-sort', 'ascending');
+    fireEvent.click(sortButton);
+    expect(costHeader).toHaveAttribute('aria-sort', 'descending');
+  });
+
+  it('expands to show flightings and opens the detail modal', async () => {
+    render(<ChannelTable plan={plan} readOnly />);
+    const targetChannel: Channel = 'Social';
+    const expandButtons = screen.getAllByRole('button', { name: /expand .* channel flightings/i });
+    const expandButton = expandButtons.find(
+      (button) => button.getAttribute('aria-controls') === `channel-${targetChannel}-panel`,
+    );
+    expect(expandButton).toBeDefined();
+    fireEvent.click(expandButton!);
+
+    expect(mockUseChannelFlightings).toHaveBeenCalledWith(plan.id, targetChannel);
+
+    const firstLineItem = plan.lineItems.find((item) => item.channel === targetChannel);
+    const vendorName = firstLineItem
+      ? plan.vendors.find((vendor) => vendor.vendor_id === firstLineItem.vendor_id)?.name
+      : undefined;
+    if (vendorName) {
+      const vendorCells = await screen.findAllByText(vendorName);
+      expect(vendorCells[0]).toBeInTheDocument();
+    }
+
+    const detailButton = await screen.findByRole('button', { name: /view additional details/i });
+    fireEvent.click(detailButton);
+
+    expect(await screen.findByRole('heading', { name: /flighting details/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /close dialog/i }));
+    await waitFor(() =>
+      expect(screen.queryByRole('heading', { name: /flighting details/i })).not.toBeInTheDocument(),
+    );
+  });
+
+  it('exposes budget share and add channel affordances when editable', () => {
+    render(<ChannelTable plan={plan} />);
+    const budgetHeaders = screen.getAllByRole('columnheader', { name: /budget %/i });
+    expect(budgetHeaders.length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: /add channel/i })).toBeInTheDocument();
+  });
+});

--- a/src/tests/MediaPlanOverviewCard.test.tsx
+++ b/src/tests/MediaPlanOverviewCard.test.tsx
@@ -1,0 +1,29 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { MediaPlanOverviewCard } from '@/components/MediaPlanOverviewCard';
+import { plans } from '@/data/seed';
+
+const plan = plans[0];
+
+describe('MediaPlanOverviewCard', () => {
+  it('shows core metadata for the media plan', () => {
+    render(<MediaPlanOverviewCard plan={plan} />);
+
+    expect(screen.getByRole('heading', { name: plan.meta.name })).toBeInTheDocument();
+    expect(screen.getByText(/Client:\s*Aurora Beverages/i)).toBeInTheDocument();
+    expect(screen.getByText(plan.meta.code)).toBeInTheDocument();
+    expect(screen.getByText(plan.owner)).toBeInTheDocument();
+    expect(screen.getByText(/Total cost/i)).toBeInTheDocument();
+  });
+
+  it('surfaces the edit action when provided', () => {
+    const onEdit = vi.fn();
+    render(<MediaPlanOverviewCard plan={plan} onEdit={onEdit} />);
+
+    const button = screen.getByRole('button', { name: /edit plan/i });
+    fireEvent.click(button);
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/ui/Modal.tsx
+++ b/src/ui/Modal.tsx
@@ -1,6 +1,15 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useId, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { Button } from './Button';
+
+const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
 
 export function Modal({
   title,
@@ -17,17 +26,83 @@ export function Modal({
   children: ReactNode;
   footer?: ReactNode;
 }) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+  const titleId = useId();
+  const descriptionId = description ? `${titleId}-description` : undefined;
+
+  useEffect(() => {
+    if (!open) return;
+
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+    const node = containerRef.current;
+    if (node) {
+      const focusable = node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
+      (focusable[0] ?? node).focus();
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+
+      if (event.key === 'Tab') {
+        const focusable = containerRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
+        if (!focusable || focusable.length === 0) {
+          event.preventDefault();
+          return;
+        }
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        const active = document.activeElement as HTMLElement | null;
+
+        if (event.shiftKey) {
+          if (active === first || !active) {
+            event.preventDefault();
+            last.focus();
+          }
+        } else if (active === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      previouslyFocused.current?.focus?.();
+    };
+  }, [open, onClose]);
+
   if (!open) return null;
 
   return createPortal(
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 p-4">
-      <div className="w-full max-w-2xl rounded-lg bg-white shadow-xl">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 p-4" role="presentation">
+      <div
+        ref={containerRef}
+        className="w-full max-w-2xl rounded-lg bg-white shadow-xl focus:outline-none"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        tabIndex={-1}
+      >
         <header className="flex items-start justify-between border-b border-slate-200 px-6 py-4">
           <div>
-            <h2 className="text-lg font-semibold">{title}</h2>
-            {description ? <p className="text-sm text-slate-500">{description}</p> : null}
+            <h2 id={titleId} className="text-lg font-semibold">
+              {title}
+            </h2>
+            {description ? (
+              <p id={descriptionId} className="text-sm text-slate-500">
+                {description}
+              </p>
+            ) : null}
           </div>
-          <Button variant="ghost" onClick={onClose} aria-label="Close">
+          <Button variant="ghost" onClick={onClose} aria-label="Close dialog">
             ×
           </Button>
         </header>

--- a/src/ui/Table.tsx
+++ b/src/ui/Table.tsx
@@ -3,27 +3,59 @@ import clsx from 'clsx';
 
 export function Table({ children, className }: { children: ReactNode; className?: string }) {
   return (
-    <div className={clsx('overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm', className)}>
+    <div
+      className={clsx(
+        'overflow-x-auto overflow-y-auto rounded-lg border border-slate-200 bg-white shadow-sm',
+        className,
+      )}
+    >
       <table className="min-w-full divide-y divide-slate-200 text-left text-sm text-slate-700">{children}</table>
     </div>
   );
 }
 
-export function THead({ children }: { children: ReactNode }) {
-  return <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-500">{children}</thead>;
+export function THead({ children, sticky = false }: { children: ReactNode; sticky?: boolean }) {
+  return (
+    <thead
+      className={clsx('bg-slate-50 text-xs uppercase tracking-wide text-slate-500', {
+        'sticky top-0 z-10': sticky,
+      })}
+    >
+      {children}
+    </thead>
+  );
 }
 
 export function TBody({ children }: { children: ReactNode }) {
   return <tbody className="divide-y divide-slate-200 bg-white">{children}</tbody>;
 }
 
-export function Th({ children }: { children: ReactNode }) {
-  return <th className="px-4 py-2 font-medium">{children}</th>;
+export function Th({
+  children,
+  ariaSort,
+}: {
+  children: ReactNode;
+  ariaSort?: 'none' | 'ascending' | 'descending';
+}) {
+  return (
+    <th className="px-4 py-2 font-medium" aria-sort={ariaSort ?? undefined} scope="col">
+      {children}
+    </th>
+  );
 }
 
-export function Td({ children, align }: { children: ReactNode; align?: 'right' | 'left' | 'center' }) {
+export function Td({
+  children,
+  align,
+  colSpan,
+}: {
+  children: ReactNode;
+  align?: 'right' | 'left' | 'center';
+  colSpan?: number;
+}) {
   return (
     <td
+      colSpan={colSpan}
       className={clsx('px-4 py-2', {
         'text-right': align === 'right',
         'text-center': align === 'center',


### PR DESCRIPTION
## Summary
- add an inline channel scaffolder with budget share summaries and read-only pulse-aware flighting rows
- support week-by-week scheduling using a flighting calendar dialog and persist pulse windows on each flight
- embed a block plan calendar preview in the export dialog and drop the sidebar budget summary in favour of row-level insights

## Testing
- npm run lint
- npm run test -- --watch=false
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d79e0ab040832192d86a4c3733e705