### PR TITLE
Add block plan scheduling view and supporting data model updates

### DIFF
--- a/docs/components/channel-table.md
+++ b/docs/components/channel-table.md
@@ -1,0 +1,77 @@
+# Channel hierarchy implementation
+
+The media plan page renders channels with a two-tier hierarchy. Each channel row summarises the
+line items assigned to that channel, and expanding a row reveals all flightings with the
+channel-specific columns required by trading and reporting teams.
+
+## Summary column dictionary
+
+`SUMMARY_COLUMNS` in `src/components/ChannelTable.tsx` defines the channel-level summary layout. The
+first eight columns—Channel, Vendor/Platform, Start, End, Pricing Model, Rate, Units, and Cost
+(Planned)—remain sticky while scrolling. Goal/KPI and Audience round out the core dataset, and the
+Audience column now resolves to a single aggregated label so the top-level view stays comparable
+across channels. The final column keeps the **View flightings** control aligned to the right edge.
+
+`buildChannelSummaries` aggregates the raw line items to populate those columns: it rolls up start
+and end dates, calculates totals, and normalises the vendor, audience, and KPI values. Channel-
+specific attributes are no longer surfaced at this tier, keeping the first row lightweight while the
+detailed breakouts live in the expandable section.
+
+## Flighting column dictionary
+
+Expanded rows render the flighting table defined by `getColumnsForChannel(channel)`. The helper
+pulls the channel-specific configuration from `CHANNEL_SPECIFIC_COLUMNS` and appends the shared
+financial columns (Vendor/Platform, Start, End, Objective, Units, Cost, Fees). Each channel mapping
+lives close to the component so reviewers can see which extension fields drive the hierarchy, and
+reusable formatters handle localisation (dates, currency, percentages) along with boolean and count
+conversions.
+
+To add a new channel type:
+
+1. Extend `CHANNEL_SPECIFIC_COLUMNS` with the desired column metadata, reusing the helper formatters
+   (e.g. `formatBoolean`, `formatFlightWindow`) where possible so values stay consistent.
+2. Update `formatObjective` and/or `formatUnits` if the new channel requires a bespoke label in the
+   shared financial columns.
+3. If the channel introduces a new extension payload, extend
+   `extensionKeyByChannel` in `src/lib/channelExtensions.ts` so both the table and details modal can
+   access the structured data.
+
+## Lazy flighting queries
+
+Channel expansion is powered by `useChannelFlightings(planId, channel)` from `src/api/plans.ts`.
+The hook reads the plan from the store on demand, filters the line items for the requested channel
+and caches the result for five minutes with React Query. The table only invokes the hook when a
+channel is expanded, keeping the default render path lightweight.
+
+## Flighting details modal
+
+`FlightDetailsModal` presents the full payload in grouped sections. The modal reads the same
+`extensionKeyByChannel` mapping to render channel-specific metadata, ensures currency and date
+formatting use the `en-AU` locale, and uses the shared `Modal` primitive to trap focus and restore
+it to the triggering disclosure button.
+
+## Extending the experience
+
+When adding support for a new channel type:
+
+- Extend `CHANNEL_SPECIFIC_COLUMNS` (or the relevant builder such as `buildAudioColumns`) alongside
+  `formatObjective`/`formatUnits`, and update the shared `extensionKeyByChannel` map as described
+  above.
+- Add representative fixtures to `src/tests/ChannelTable.test.tsx` so the unique column rendering is
+  exercised in tests.
+- Consider updating the `plans` seed to include at least one line item for the new channel so
+  preview environments demonstrate the full hierarchy.
+
+## Channel creation
+
+Editable plans surface an **Add channel** action next to the table title. Triggering the dialog
+provisions a minimal flight, audience, vendor, creative, tracking payload, and channel-specific
+extension with placeholder values so planners can immediately start capturing details.
+
+## Pulsed scheduling
+
+Flight rows expose an **Edit schedule** button that launches `FlightingScheduleDialog`. The dialog
+presents a week-by-week selector so planners can capture pulsing behaviour—weeks toggle between
+active and dark periods, and the dialog persists the selection to
+`flight.active_periods_json`. Those pulse windows feed the channel summary rollups, the details
+modal, and the block plan preview inside the export dialog.

--- a/docs/previews/media-plan-previews.md
+++ b/docs/previews/media-plan-previews.md
@@ -1,0 +1,8 @@
+# Media Plan UI Previews
+
+The screenshots below capture the current Media Planner workflow referenced in QA updates.
+
+- **Dashboard** – plan overview with card/list toggle and prominent client metadata.
+- **Plan detail** – hierarchical channel table with expandable flightings and detail modal trigger.
+
+To regenerate locally, run `npm run dev -- --host 0.0.0.0 --port 4173` and capture the screens via Playwright or your preferred tool.

--- a/docs/qa/media-planning-process.md
+++ b/docs/qa/media-planning-process.md
@@ -1,0 +1,36 @@
+# Media Planning Workflow QA – 2025-03-01
+
+## Environment
+- Vite dev server (`npm run dev -- --host 0.0.0.0 --port 4173`)
+- Authentication mode: mock (default for local development)
+
+## Test Scenarios
+
+### 1. Authentication Header
+- Launch application and confirm automatic mock sign-in displays planner identity in the header.
+- ✅ Result: Header shows "Signed in as Taylor Planner" with role selector.
+
+### 2. Create New Plan
+- From Dashboard click **New Plan**.
+- ✅ Result: Navigated to plan editor for a new draft plan with default metadata (`New Plan` / auto-generated code).
+
+### 3. Edit Plan Metadata
+- Update plan name to "QA Automation Plan" and code to "QA-2025-SPRING".
+- ✅ Result: Autosave updates persisted and reflected in dashboard summary.
+
+### 4. Submit Plan for Approval
+- Click **Submit for Approval** on the editor.
+- ✅ Result: Status chip switched to `Submitted`, actions update to show **Revert to Draft**.
+
+### 5. Dashboard Status Refresh
+- Return to dashboard and verify the new plan card reflects `Submitted` state.
+- ✅ Result: Card shows latest status and metadata.
+
+### 6. Budget Adjustment Regression
+- Open seeded "Aurora Sparkling FY25 Launch" plan, adjust first line item's planned cost, confirm table updates, then revert value.
+- ✅ Result: Planned cost reflected new value immediately in both allocator and channel table, confirming mutation workflow.
+
+## Noted Limitations
+- The new add-channel scaffolder seeds placeholder vendors, creatives, and flights; planners still need dedicated edit forms to replace the stub data before export.
+- Firebase authentication cannot be exercised locally without providing the required `VITE_FIREBASE_*` variables.
+

--- a/src/api/plans.ts
+++ b/src/api/plans.ts
@@ -1,6 +1,15 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { store } from '@/store';
-import type { Plan } from '@/lib/schemas';
+import type {
+  Plan,
+  Channel,
+  LineItem,
+  Flight,
+  Audience,
+  Vendor,
+  Creative,
+  Tracking,
+} from '@/lib/schemas';
 
 const planKeys = {
   all: ['plans'] as const,
@@ -102,5 +111,51 @@ export function useRevertPlan() {
       client.invalidateQueries({ queryKey: planKeys.all });
       client.setQueryData(planKeys.detail(plan.id), plan);
     },
+  });
+}
+
+export type ChannelFlighting = {
+  lineItem: LineItem;
+  flight?: Flight;
+  audience?: Audience;
+  vendor?: Vendor;
+  creative?: Creative;
+  tracking?: Tracking;
+};
+
+export function useChannelFlightings(planId: string | undefined, channel: Channel) {
+  return useQuery({
+    enabled: Boolean(planId),
+    queryKey: [...planKeys.detail(planId ?? 'unknown'), 'channel-flightings', channel],
+    queryFn: async (): Promise<ChannelFlighting[]> => {
+      if (!planId) return [];
+      const plan = await store.getPlan(planId);
+      if (!plan) {
+        throw new Error('Plan not found');
+      }
+
+      const flightsById = new Map(plan.flights.map((flight) => [flight.flight_id, flight]));
+      const audiencesById = new Map(plan.audiences.map((audience) => [audience.audience_id, audience]));
+      const vendorsById = new Map(plan.vendors.map((vendor) => [vendor.vendor_id, vendor]));
+      const creativesById = new Map(plan.creatives.map((creative) => [creative.creative_id, creative]));
+      const trackingByLine = new Map(plan.tracking.map((tracking) => [tracking.line_item_id, tracking]));
+
+      return plan.lineItems
+        .filter((item) => item.channel === channel)
+        .map((lineItem) => ({
+          lineItem,
+          flight: flightsById.get(lineItem.flight_id),
+          audience: audiencesById.get(lineItem.audience_id),
+          vendor: vendorsById.get(lineItem.vendor_id),
+          creative: creativesById.get(lineItem.creative_id),
+          tracking: trackingByLine.get(lineItem.line_item_id),
+        }))
+        .sort((a, b) => {
+          const aDate = a.flight ? new Date(a.flight.start_date).getTime() : Number.POSITIVE_INFINITY;
+          const bDate = b.flight ? new Date(b.flight.start_date).getTime() : Number.POSITIVE_INFINITY;
+          return aDate - bDate;
+        });
+    },
+    staleTime: 5 * 60 * 1000,
   });
 }

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -2,6 +2,7 @@ import { Route, Routes } from 'react-router-dom';
 import { DashboardPage } from '@/pages/DashboardPage';
 import { MediaPlanningPage } from '@/pages/MediaPlanningPage';
 import { PlanDetailPage } from '@/pages/PlanDetailPage';
+import { BlockPlanPage } from '@/pages/BlockPlanPage';
 import { NotFoundPage } from '@/pages/NotFoundPage';
 
 export function AppRoutes() {
@@ -9,6 +10,7 @@ export function AppRoutes() {
     <Routes>
       <Route path="/" element={<DashboardPage />} />
       <Route path="/plan/:id" element={<MediaPlanningPage />} />
+      <Route path="/plan/:id/block" element={<BlockPlanPage />} />
       <Route path="/plan/:id/review" element={<PlanDetailPage />} />
       <Route path="*" element={<NotFoundPage />} />
     </Routes>

--- a/src/components/ChannelTable.tsx
+++ b/src/components/ChannelTable.tsx
@@ -1,196 +1,813 @@
-import { Fragment, useMemo, useState } from 'react';
-import type { LineItem, Plan } from '@/lib/schemas';
-import { Table, THead, TBody, Th, Td } from '@/ui/Table';
+import { Fragment, useEffect, useMemo, useState } from 'react';
+import clsx from 'clsx';
+import { channelTableConfig, type ColumnSpec } from '@/config/channelTableConfig';
+import {
+  buildFlightingContexts,
+  computeChannelSummaries,
+  getFieldValue,
+  setFieldValue,
+  validateField,
+  type ChannelSummary,
+  type FlightingRowContext,
+  type FlightingValue,
+} from '@/lib/channelTable';
+import type { Channel, Plan } from '@/lib/schemas';
 import { currencyFormatter, numberFormatter } from '@/lib/formatters';
-import { formatDateRange } from '@/lib/date';
-import { flags } from '@/app/featureFlags';
+import { formatDate } from '@/lib/date';
+import { Button } from '@/ui/Button';
+import { Select } from '@/ui/Select';
+import { Table, THead, TBody, Th, Td } from '@/ui/Table';
+import { useMutatePlan, type ChannelFlighting } from '@/api/plans';
+import { addFlighting, duplicateFlighting, removeFlighting } from '@/lib/planBuilders';
+import { FlightDetailsModal } from './FlightDetailsModal';
 
-function formatValue(value: unknown): string {
-  if (value === undefined || value === null) return '—';
-  if (Array.isArray(value)) {
-    return value.map((item) => formatValue(item)).join(', ');
-  }
-  if (typeof value === 'object') {
-    return JSON.stringify(value);
-  }
-  if (typeof value === 'number') {
-    if (Number.isInteger(value)) return numberFormatter.format(value);
-    return value.toLocaleString(undefined, { maximumFractionDigits: 2 });
-  }
-  return String(value);
+type ChannelTableProps = {
+  plan: Plan;
+  readOnly?: boolean;
+};
+
+type SortKey = 'channel' | 'start_date' | 'end_date' | 'total_planned_cost' | 'budget_percent';
+
+type SortState = {
+  key: SortKey;
+  direction: 'asc' | 'desc';
+};
+
+type Filters = {
+  channel?: Channel;
+  costMin?: string;
+  costMax?: string;
+  start?: string;
+  end?: string;
+};
+
+type CellErrorMap = Record<string, Record<string, string>>;
+
+type FlightingTotals = Record<string, number>;
+
+const COMMON_COLUMN_COUNT = channelTableConfig.flightingCommonColumns.length;
+
+function formatPercentValue(value: number, precision?: number) {
+  return new Intl.NumberFormat('en-AU', {
+    style: 'percent',
+    maximumFractionDigits: precision ?? 1,
+  }).format(value);
 }
 
-function getExtension(lineItem: LineItem) {
-  return (
-    lineItem.ooh_ext ??
-    lineItem.tv_ext ??
-    lineItem.bvod_ext ??
-    lineItem.digital_ext ??
-    lineItem.social_ext ??
-    lineItem.search_ext ??
-    lineItem.audio_ext ??
-    lineItem.podcast_ext ??
-    lineItem.cinema_ext ??
-    lineItem.print_ext ??
-    lineItem.retail_media_ext ??
-    lineItem.influencer_ext ??
-    lineItem.sponsorship_ext ??
-    lineItem.email_dm_ext ??
-    lineItem.gaming_native_ext ??
-    lineItem.affiliate_ext ??
-    undefined
-  );
+function formatDisplayValue(column: ColumnSpec, value: FlightingValue) {
+  if (value == null || value === '') {
+    return '—';
+  }
+  switch (column.type) {
+    case 'date':
+      return typeof value === 'string' ? formatDate(value) : '—';
+    case 'currency':
+      return currencyFormatter.format(Number(value));
+    case 'percent':
+      return formatPercentValue(Number(value), column.precision);
+    case 'number':
+      return numberFormatter.format(Number(value));
+    case 'boolean':
+      return value ? 'Yes' : 'No';
+    default:
+      return String(value);
+  }
 }
 
-function LineItemDetails({ plan, lineItem }: { plan: Plan; lineItem: LineItem }) {
-  const flight = plan.flights.find((item) => item.flight_id === lineItem.flight_id);
-  const campaign = flight ? plan.campaigns.find((item) => item.campaign_id === flight.campaign_id) : undefined;
-  const audience = plan.audiences.find((item) => item.audience_id === lineItem.audience_id);
-  const vendor = plan.vendors.find((item) => item.vendor_id === lineItem.vendor_id);
-  const creative = plan.creatives.find((item) => item.creative_id === lineItem.creative_id);
-  const tracking = plan.tracking.find((item) => item.line_item_id === lineItem.line_item_id);
-  const actuals = useMemo(
-    () => plan.deliveryActuals.filter((item) => item.line_item_id === lineItem.line_item_id),
-    [plan.deliveryActuals, lineItem.line_item_id],
-  );
-  const extension = getExtension(lineItem);
+function valueToInput(column: ColumnSpec, value: FlightingValue): string | number | boolean {
+  if (value == null) {
+    if (column.type === 'boolean') return false;
+    return '';
+  }
+  switch (column.type) {
+    case 'percent':
+      return Number(value) * 100;
+    case 'number':
+    case 'currency':
+      return Number(value);
+    case 'boolean':
+      return Boolean(value);
+    default:
+      return String(value);
+  }
+}
 
-  const extensionEntries = extension ? Object.entries(extension).map(([key, value]) => [key, formatValue(value)]) : [];
+function inputToValue(column: ColumnSpec, input: unknown): FlightingValue {
+  switch (column.type) {
+    case 'percent': {
+      const numeric = Number(input);
+      if (!Number.isFinite(numeric)) return 0;
+      return numeric / 100;
+    }
+    case 'currency':
+    case 'number': {
+      const numeric = Number(input);
+      if (!Number.isFinite(numeric)) return 0;
+      return numeric;
+    }
+    case 'boolean':
+      return Boolean(input);
+    default:
+      return typeof input === 'string' ? input : String(input ?? '');
+  }
+}
 
-  const totals = actuals.reduce(
-    (acc, row) => ({
-      impressions: acc.impressions + (row.impressions ?? 0),
-      clicks: acc.clicks + (row.clicks ?? 0),
-      conversions: acc.conversions + (row.conversions ?? 0),
-      cost: acc.cost + (row.actual_cost ?? 0),
-    }),
-    { impressions: 0, clicks: 0, conversions: 0, cost: 0 },
+function cumulativeStickyOffsets(columns: ColumnSpec[], stickyCount: number) {
+  const offsets: number[] = [];
+  let accumulator = 0;
+  for (let index = 0; index < columns.length; index += 1) {
+    if (index < stickyCount) {
+      offsets.push(accumulator);
+      const width = columns[index]?.width ?? 160;
+      accumulator += width;
+    } else {
+      offsets.push(0);
+    }
+  }
+  return offsets;
+}
+
+function applyFilters(summaries: ChannelSummary[], filters: Filters) {
+  return summaries.filter((summary) => {
+    if (filters.channel && summary.channel !== filters.channel) {
+      return false;
+    }
+    if (filters.costMin) {
+      const min = Number(filters.costMin);
+      if (Number.isFinite(min) && summary.totalPlannedCost < min) {
+        return false;
+      }
+    }
+    if (filters.costMax) {
+      const max = Number(filters.costMax);
+      if (Number.isFinite(max) && summary.totalPlannedCost > max) {
+        return false;
+      }
+    }
+    if (filters.start) {
+      if (!summary.startDate || new Date(summary.startDate) < new Date(filters.start)) {
+        return false;
+      }
+    }
+    if (filters.end) {
+      if (!summary.endDate || new Date(summary.endDate) > new Date(filters.end)) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+function sortSummaries(summaries: ChannelSummary[], sort: SortState | null) {
+  if (!sort) return summaries;
+  return [...summaries].sort((a, b) => {
+    const direction = sort.direction === 'asc' ? 1 : -1;
+    switch (sort.key) {
+      case 'channel':
+        return a.channel.localeCompare(b.channel) * direction;
+      case 'start_date':
+        return ((a.startDate ?? '') > (b.startDate ?? '') ? 1 : -1) * direction;
+      case 'end_date':
+        return ((a.endDate ?? '') > (b.endDate ?? '') ? 1 : -1) * direction;
+      case 'total_planned_cost':
+        return (a.totalPlannedCost - b.totalPlannedCost) * direction;
+      case 'budget_percent':
+        return (a.budgetPercent - b.budgetPercent) * direction;
+      default:
+        return 0;
+    }
+  });
+}
+
+function createChannelFlighting(plan: Plan, context: FlightingRowContext): ChannelFlighting {
+  const creative = plan.creatives.find((item) => item.creative_id === context.lineItem.creative_id);
+  const tracking = plan.tracking.find((item) => item.line_item_id === context.lineItem.line_item_id);
+  return {
+    lineItem: context.lineItem,
+    flight: context.flight,
+    vendor: context.vendor,
+    audience: context.audience,
+    creative,
+    tracking,
+  };
+}
+
+export function ChannelTable({ plan, readOnly }: ChannelTableProps) {
+  const mutatePlan = useMutatePlan();
+  const [workingPlan, setWorkingPlan] = useState(plan);
+  const [expandedChannels, setExpandedChannels] = useState<Set<Channel>>(new Set());
+  const [sort, setSort] = useState<SortState>({ key: 'channel', direction: 'asc' });
+  const [filters, setFilters] = useState<Filters>({});
+  const [errors, setErrors] = useState<CellErrorMap>({});
+  const [modalFlighting, setModalFlighting] = useState<ChannelFlighting | null>(null);
+  const [emptyChannels, setEmptyChannels] = useState<Set<Channel>>(new Set());
+
+  useEffect(() => {
+    setWorkingPlan(plan);
+    setEmptyChannels((current) => {
+      const withData = new Set(computeChannelSummaries(plan).map((summary) => summary.channel));
+      const next = new Set<Channel>();
+      current.forEach((channel) => {
+        if (!withData.has(channel)) {
+          next.add(channel);
+        }
+      });
+      return next;
+    });
+  }, [plan]);
+
+  const summaries = useMemo(() => {
+    const computed = computeChannelSummaries(workingPlan);
+    const withData = new Set(computed.map((summary) => summary.channel));
+    const manual = Array.from(emptyChannels)
+      .filter((channel) => !withData.has(channel))
+      .map((channel) => ({
+        channel,
+        startDate: null,
+        endDate: null,
+        totalPlannedCost: 0,
+        budgetPercent: 0,
+        lineItemIds: [],
+      }));
+    return [...computed, ...manual].sort((a, b) => a.channel.localeCompare(b.channel));
+  }, [workingPlan, emptyChannels]);
+  const filteredSummaries = useMemo(() => applyFilters(summaries, filters), [summaries, filters]);
+  const sortedSummaries = useMemo(() => sortSummaries(filteredSummaries, sort), [filteredSummaries, sort]);
+
+  const stickyOffsets = useMemo(
+    () => cumulativeStickyOffsets(channelTableConfig.topLevelColumns, channelTableConfig.topLevelColumns.length - 1),
+    [],
   );
+
+  const handleToggle = (channel: Channel) => {
+    setExpandedChannels((current) => {
+      const next = new Set(current);
+      if (next.has(channel)) {
+        next.delete(channel);
+      } else {
+        next.add(channel);
+      }
+      return next;
+    });
+  };
+
+  const updatePlan = (next: Plan) => {
+    setWorkingPlan(next);
+    mutatePlan.mutate(next);
+  };
+
+  const handleAddFlighting = (channel: Channel) => {
+    const nextPlan = addFlighting(workingPlan, channel);
+    updatePlan(nextPlan);
+    setExpandedChannels((current) => new Set(current).add(channel));
+    setEmptyChannels((current) => {
+      const next = new Set(current);
+      next.delete(channel);
+      return next;
+    });
+  };
+
+  const handleDuplicateFlighting = (lineItemId: string) => {
+    const nextPlan = duplicateFlighting(workingPlan, lineItemId);
+    updatePlan(nextPlan);
+  };
+
+  const handleRemoveFlighting = (channel: Channel, lineItemId: string) => {
+    setErrors((current) => {
+      const next = { ...current };
+      delete next[lineItemId];
+      return next;
+    });
+    const nextPlan = removeFlighting(workingPlan, lineItemId);
+    updatePlan(nextPlan);
+    const contexts = buildFlightingContexts(nextPlan, channel);
+    if (contexts.length === 0) {
+      setEmptyChannels((current) => {
+        const next = new Set(current);
+        next.add(channel);
+        return next;
+      });
+    }
+  };
+
+  const handleSort = (key: SortKey) => {
+    setSort((current) => {
+      if (current?.key === key) {
+        return { key, direction: current.direction === 'asc' ? 'desc' : 'asc' };
+      }
+      return { key, direction: 'asc' };
+    });
+  };
+
+  const topColumns = channelTableConfig.topLevelColumns;
 
   return (
-    <div className="space-y-4 rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        <div>
-          <p className="text-xs uppercase tracking-wide text-slate-500">Campaign</p>
-          <p className="font-medium text-slate-800">{campaign?.brand ?? '—'}</p>
-          <p className="text-xs text-slate-500">{campaign?.objective ?? 'No objective recorded'}</p>
-        </div>
-        <div>
-          <p className="text-xs uppercase tracking-wide text-slate-500">Audience</p>
-          <p className="font-medium text-slate-800">{audience?.definition ?? '—'}</p>
-          <p className="text-xs text-slate-500">Segments: {formatValue(audience?.segments_json)}</p>
-        </div>
-        <div>
-          <p className="text-xs uppercase tracking-wide text-slate-500">Creative</p>
-          <p className="font-medium text-slate-800">{creative?.ad_name ?? '—'}</p>
-          <p className="text-xs text-slate-500">Format: {creative?.format ?? '—'}</p>
-        </div>
-        <div>
-          <p className="text-xs uppercase tracking-wide text-slate-500">Vendor Contact</p>
-          <p className="font-medium text-slate-800">{vendor?.name ?? '—'}</p>
-          <p className="text-xs text-slate-500">{formatValue(vendor?.contact_json)}</p>
-        </div>
-        <div>
-          <p className="text-xs uppercase tracking-wide text-slate-500">Tracking</p>
-          <p className="font-medium text-slate-800">{tracking?.ad_server ?? '—'}</p>
-          <p className="text-xs text-slate-500">Verification: {tracking?.verification_vendor ?? '—'}</p>
-        </div>
-        <div>
-          <p className="text-xs uppercase tracking-wide text-slate-500">Actuals (to date)</p>
-          <p className="font-medium text-slate-800">
-            {numberFormatter.format(totals.impressions)} imp • {numberFormatter.format(totals.clicks)} clicks
-          </p>
-          <p className="text-xs text-slate-500">
-            {numberFormatter.format(totals.conversions)} conv • {currencyFormatter.format(totals.cost)} cost
-          </p>
-        </div>
-      </div>
-      {extensionEntries.length > 0 ? (
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Channel Details</p>
-          <dl className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
-            {extensionEntries.map(([key, value]) => (
-              <div key={key} className="rounded border border-slate-200 bg-white p-2">
-                <dt className="text-xs uppercase tracking-wide text-slate-400">{key.replace(/_/g, ' ')}</dt>
-                <dd className="text-sm font-medium text-slate-800">{value}</dd>
-              </div>
+    <section aria-labelledby="channel-table" className="space-y-4">
+      <div className="flex flex-wrap items-end gap-4">
+        <div className="flex flex-col text-sm">
+          <label htmlFor="channel-filter" className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            Channel
+          </label>
+          <select
+            id="channel-filter"
+            className="mt-1 rounded-md border border-slate-300 p-2 text-sm"
+            value={filters.channel ?? ''}
+            onChange={(event) =>
+              setFilters((current) => ({
+                ...current,
+                channel: (event.target.value as Channel) || undefined,
+              }))
+            }
+          >
+            <option value="">All channels</option>
+            {Array.from(new Set(summaries.map((summary) => summary.channel))).map((channel) => (
+              <option key={channel} value={channel}>
+                {channel.replace(/_/g, ' ')}
+              </option>
             ))}
-          </dl>
+          </select>
         </div>
-      ) : null}
+        <div className="flex flex-col text-sm">
+          <label htmlFor="cost-min" className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            Min cost (AUD)
+          </label>
+          <input
+            id="cost-min"
+            type="number"
+            className="mt-1 w-32 rounded-md border border-slate-300 p-2 text-sm"
+            value={filters.costMin ?? ''}
+            onChange={(event) => setFilters((current) => ({ ...current, costMin: event.target.value }))}
+          />
+        </div>
+        <div className="flex flex-col text-sm">
+          <label htmlFor="cost-max" className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            Max cost (AUD)
+          </label>
+          <input
+            id="cost-max"
+            type="number"
+            className="mt-1 w-32 rounded-md border border-slate-300 p-2 text-sm"
+            value={filters.costMax ?? ''}
+            onChange={(event) => setFilters((current) => ({ ...current, costMax: event.target.value }))}
+          />
+        </div>
+        <div className="flex flex-col text-sm">
+          <label htmlFor="start-filter" className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            Earliest start
+          </label>
+          <input
+            id="start-filter"
+            type="date"
+            className="mt-1 rounded-md border border-slate-300 p-2 text-sm"
+            value={filters.start ?? ''}
+            onChange={(event) => setFilters((current) => ({ ...current, start: event.target.value }))}
+          />
+        </div>
+        <div className="flex flex-col text-sm">
+          <label htmlFor="end-filter" className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            Latest end
+          </label>
+          <input
+            id="end-filter"
+            type="date"
+            className="mt-1 rounded-md border border-slate-300 p-2 text-sm"
+            value={filters.end ?? ''}
+            onChange={(event) => setFilters((current) => ({ ...current, end: event.target.value }))}
+          />
+        </div>
+        <Button variant="secondary" onClick={() => setFilters({})}>
+          Reset filters
+        </Button>
+      </div>
+
+      <Table>
+        <THead sticky>
+          <tr>
+            {topColumns.map((column, index) => (
+              <Th
+                key={column.id}
+                ariaSort={sort?.key === column.id ? (sort.direction === 'asc' ? 'ascending' : 'descending') : 'none'}
+                className={clsx('bg-white', {
+                  'cursor-pointer select-none': ['channel', 'start_date', 'end_date', 'total_planned_cost', 'budget_percent'].includes(
+                    column.id,
+                  ),
+                })}
+                style={index < topColumns.length - 1 ? { position: 'sticky', left: stickyOffsets[index], zIndex: 5, background: 'white' } : undefined}
+                onClick={() =>
+                  ['channel', 'start_date', 'end_date', 'total_planned_cost', 'budget_percent'].includes(column.id) &&
+                  handleSort(column.id as SortKey)
+                }
+              >
+                {column.label}
+              </Th>
+            ))}
+          </tr>
+        </THead>
+        <TBody>
+          {sortedSummaries.length === 0 ? (
+            <tr>
+              <Td colSpan={topColumns.length} className="text-sm text-slate-500">
+                No channels match the current filters.
+              </Td>
+            </tr>
+          ) : (
+            sortedSummaries.map((summary) => {
+              const isExpanded = expandedChannels.has(summary.channel);
+              const panelId = `channel-${summary.channel}-flightings`;
+              return (
+                <Fragment key={summary.channel}>
+                  <tr className={clsx('transition-colors', { 'bg-slate-50': isExpanded })}>
+                    {topColumns.map((column, columnIndex) => {
+                      switch (column.id) {
+                        case 'channel':
+                          return (
+                            <Td
+                              key={column.id}
+                              style={{ position: 'sticky', left: stickyOffsets[columnIndex], background: 'white' }}
+                            >
+                              {summary.channel.replace(/_/g, ' ')}
+                            </Td>
+                          );
+                        case 'start_date':
+                          return (
+                            <Td
+                              key={column.id}
+                              style={{ position: 'sticky', left: stickyOffsets[columnIndex], background: 'white' }}
+                            >
+                              {summary.startDate ? formatDate(summary.startDate) : '—'}
+                            </Td>
+                          );
+                        case 'end_date':
+                          return (
+                            <Td
+                              key={column.id}
+                              style={{ position: 'sticky', left: stickyOffsets[columnIndex], background: 'white' }}
+                            >
+                              {summary.endDate ? formatDate(summary.endDate) : '—'}
+                            </Td>
+                          );
+                        case 'total_planned_cost':
+                          return (
+                            <Td
+                              key={column.id}
+                              align="right"
+                              style={{ position: 'sticky', left: stickyOffsets[columnIndex], background: 'white' }}
+                            >
+                              {currencyFormatter.format(summary.totalPlannedCost)}
+                            </Td>
+                          );
+                        case 'budget_percent':
+                          return (
+                            <Td
+                              key={column.id}
+                              align="right"
+                              style={{ position: 'sticky', left: stickyOffsets[columnIndex], background: 'white' }}
+                            >
+                              {formatPercentValue(summary.budgetPercent, column.precision)}
+                            </Td>
+                          );
+                        case 'actions':
+                          return (
+                            <Td key={column.id} align="right">
+                              <Button
+                                variant="ghost"
+                                aria-expanded={isExpanded}
+                                aria-controls={panelId}
+                                onClick={() => handleToggle(summary.channel)}
+                              >
+                                {isExpanded ? 'Hide flightings' : 'View flightings'}
+                              </Button>
+                            </Td>
+                          );
+                        default:
+                          return <Td key={column.id}>—</Td>;
+                      }
+                    })}
+                    </tr>
+                    {isExpanded ? (
+                      <tr>
+                        <Td colSpan={topColumns.length} className="bg-slate-50 p-0" id={panelId}>
+                          <FlightingTable
+                            key={`flighting-${summary.channel}`}
+                            plan={workingPlan}
+                            channel={summary.channel}
+                            readOnly={Boolean(readOnly)}
+                            errors={errors}
+                            onDuplicate={handleDuplicateFlighting}
+                            onDelete={(lineItemId) => handleRemoveFlighting(summary.channel, lineItemId)}
+                            onUpdateErrors={setErrors}
+                            onPlanChange={updatePlan}
+                            onOpenDetails={(flight) => setModalFlighting(flight)}
+                            onAddFlighting={() => handleAddFlighting(summary.channel)}
+                          />
+                        </Td>
+                      </tr>
+                    ) : null}
+                </Fragment>
+              );
+            })
+          )}
+        </TBody>
+      </Table>
+
+      <FlightDetailsModal flighting={modalFlighting} open={Boolean(modalFlighting)} onClose={() => setModalFlighting(null)} />
+    </section>
+  );
+}
+
+type FlightingTableProps = {
+  plan: Plan;
+  channel: Channel;
+  readOnly: boolean;
+  errors: CellErrorMap;
+  onPlanChange: (plan: Plan) => void;
+  onDuplicate: (lineItemId: string) => void;
+  onDelete: (lineItemId: string) => void;
+  onUpdateErrors: (errors: CellErrorMap) => void;
+  onOpenDetails: (flighting: ChannelFlighting) => void;
+  onAddFlighting: () => void;
+};
+
+function FlightingTable({
+  plan,
+  channel,
+  readOnly,
+  errors,
+  onPlanChange,
+  onDuplicate,
+  onDelete,
+  onUpdateErrors,
+  onOpenDetails,
+  onAddFlighting,
+}: FlightingTableProps) {
+  const contexts = buildFlightingContexts(plan, channel);
+  const columns = useMemo(
+    () => [
+      ...channelTableConfig.flightingCommonColumns,
+      ...(channelTableConfig.channelSpecificColumns[channel] ?? []),
+    ],
+    [channel],
+  );
+  const stickyOffsets = useMemo(
+    () => cumulativeStickyOffsets(columns, COMMON_COLUMN_COUNT),
+    [columns],
+  );
+
+  const totals: FlightingTotals = {};
+
+  const updateErrorState = (lineItemId: string, field: string, message: string | null) => {
+    onUpdateErrors((current) => {
+      const next = { ...current };
+      const entry = { ...(next[lineItemId] ?? {}) };
+      if (message) {
+        entry[field] = message;
+      } else {
+        delete entry[field];
+      }
+      if (Object.keys(entry).length > 0) {
+        next[lineItemId] = entry;
+      } else {
+        delete next[lineItemId];
+      }
+      return next;
+    });
+  };
+
+  const handleCommit = (context: FlightingRowContext, column: ColumnSpec, rawValue: unknown) => {
+    const value = inputToValue(column, rawValue);
+    const issue = validateField(channel, context, column.id, value);
+    if (issue) {
+      updateErrorState(context.lineItem.line_item_id, column.id, issue.message);
+      return;
+    }
+    const result = setFieldValue(channel, context, column.id, value);
+    updateErrorState(context.lineItem.line_item_id, column.id, null);
+    onPlanChange(result.plan);
+  };
+
+  return (
+    <div className="rounded-b-lg border border-slate-200 bg-white shadow-sm">
+      <div className="overflow-x-auto">
+        <table className="w-full table-fixed border-collapse text-left text-sm text-slate-700">
+          <thead className="bg-slate-100 text-xs uppercase tracking-wide text-slate-500">
+            <tr>
+              {columns.map((column, index) => {
+                const width = column.width;
+                const widthStyle = width ? { width, minWidth: width } : {};
+                const stickyStyle =
+                  index < COMMON_COLUMN_COUNT
+                    ? { position: 'sticky' as const, left: stickyOffsets[index], background: '#f1f5f9', zIndex: 4 }
+                    : {};
+                return (
+                  <th
+                    key={column.id}
+                    className="border-b border-slate-200 px-4 py-2 font-medium"
+                    style={{ ...widthStyle, ...stickyStyle }}
+                  >
+                    {column.label}
+                  </th>
+                );
+              })}
+              <th className="border-b border-slate-200 px-4 py-2 text-right font-medium" style={{ width: 180, minWidth: 180 }}>
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {contexts.map((context) => {
+              const rowErrors = errors[context.lineItem.line_item_id] ?? {};
+              columns.forEach((column) => {
+                if (['number', 'currency'].includes(column.type)) {
+                  const raw = getFieldValue(channel, context, column.id);
+                  const numeric = Number(raw);
+                  if (Number.isFinite(numeric)) {
+                    totals[column.id] = (totals[column.id] ?? 0) + numeric;
+                  }
+                }
+              });
+
+              return (
+                <tr key={context.lineItem.line_item_id} className="border-b border-slate-200 last:border-b-0">
+                  {columns.map((column, index) => {
+                    const value = getFieldValue(channel, context, column.id);
+                    const inputValue = valueToInput(column, value);
+                    const editable = !readOnly && column.editable !== false;
+                    const error = rowErrors[column.id];
+                    const width = column.width;
+                    const widthStyle = width ? { width, minWidth: width } : {};
+                    const stickyStyle =
+                      index < COMMON_COLUMN_COUNT
+                        ? {
+                            position: 'sticky' as const,
+                            left: stickyOffsets[index],
+                            background: index === 0 ? '#ffffff' : '#f8fafc',
+                            zIndex: 3,
+                          }
+                        : {};
+                    return (
+                      <td
+                        key={column.id}
+                        className={clsx('px-4 py-3 align-top', {
+                          'bg-white': index >= COMMON_COLUMN_COUNT,
+                          'bg-slate-50': index < COMMON_COLUMN_COUNT,
+                          'text-center': column.align === 'center',
+                          'text-right': column.align === 'right' || ['number', 'currency', 'percent'].includes(column.type),
+                        })}
+                        style={{ ...widthStyle, ...stickyStyle }}
+                      >
+                        {editable ? (
+                          <EditableCell
+                            column={column}
+                            value={inputValue}
+                            onCommit={(next) => handleCommit(context, column, next)}
+                            error={error}
+                          />
+                        ) : (
+                          <span className="text-slate-900">{formatDisplayValue(column, value)}</span>
+                        )}
+                        {error ? <p className="mt-1 text-xs text-rose-600">{error}</p> : null}
+                      </td>
+                    );
+                  })}
+                  <td className="px-4 py-3" style={{ width: 180, minWidth: 180 }}>
+                    <div className="flex justify-end gap-2">
+                      <Button variant="ghost" onClick={() => onOpenDetails(createChannelFlighting(plan, context))}>
+                        View details
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        disabled={readOnly}
+                        onClick={() => onDuplicate(context.lineItem.line_item_id)}
+                      >
+                        Duplicate
+                      </Button>
+                      <Button
+                        variant="danger"
+                        disabled={readOnly}
+                        onClick={() => onDelete(context.lineItem.line_item_id)}
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+          {contexts.length > 0 ? (
+            <tfoot className="bg-slate-100 text-sm font-medium text-slate-700">
+              <tr className="border-t border-slate-200">
+                {columns.map((column, index) => {
+                  const total = totals[column.id];
+                  const display =
+                    total != null && ['number', 'currency'].includes(column.type)
+                      ? column.type === 'currency'
+                        ? currencyFormatter.format(total)
+                        : numberFormatter.format(total)
+                      : index === 0
+                        ? 'Totals'
+                        : '';
+                  const width = column.width;
+                  const widthStyle = width ? { width, minWidth: width } : {};
+                  const stickyStyle =
+                    index < COMMON_COLUMN_COUNT
+                      ? { position: 'sticky' as const, left: stickyOffsets[index], background: '#e2e8f0', zIndex: 2 }
+                      : {};
+                  return (
+                    <td
+                      key={column.id}
+                      className={clsx('px-4 py-2', {
+                        'font-semibold text-slate-900': index === 0,
+                        'text-right': ['number', 'currency'].includes(column.type),
+                      })}
+                      style={{ ...widthStyle, ...stickyStyle }}
+                    >
+                      {display}
+                    </td>
+                  );
+                })}
+                <td className="px-4 py-2" style={{ width: 180, minWidth: 180 }} />
+              </tr>
+            </tfoot>
+          ) : null}
+        </table>
+      </div>
+      <div className="border-t border-slate-200 px-4 py-3">
+        <Button disabled={readOnly} onClick={onAddFlighting}>
+          Add flighting
+        </Button>
+      </div>
     </div>
   );
 }
 
-export function ChannelTable({ plan }: { plan: Plan; readOnly?: boolean }) {
-  const [expandedId, setExpandedId] = useState<string | null>(null);
-  const enableDetails = flags.mediaModelV1;
+type EditableCellProps = {
+  column: ColumnSpec;
+  value: string | number | boolean;
+  onCommit: (value: string | number | boolean) => void;
+  error?: string;
+};
 
-  const toggle = (id: string) => {
-    if (!enableDetails) return;
-    setExpandedId((current) => (current === id ? null : id));
+function EditableCell({ column, value, onCommit }: EditableCellProps) {
+  const [draft, setDraft] = useState<string | number | boolean>(value);
+
+  useEffect(() => {
+    setDraft(value);
+  }, [value]);
+
+  const handleBlur = () => {
+    onCommit(draft);
   };
 
-  return (
-    <Table>
-      <THead>
-        <tr>
-          <Th>Line Item</Th>
-          <Th>Campaign</Th>
-          <Th>Flight</Th>
-          <Th>Channel</Th>
-          <Th>Vendor</Th>
-          <Th>Pricing</Th>
-          <Th align="right">Units Planned</Th>
-          <Th align="right">Planned Cost</Th>
-        </tr>
-      </THead>
-      <TBody>
-        {plan.lineItems.map((lineItem) => {
-          const flight = plan.flights.find((item) => item.flight_id === lineItem.flight_id);
-          const campaign = flight
-            ? plan.campaigns.find((item) => item.campaign_id === flight.campaign_id)
-            : undefined;
-          const vendor = plan.vendors.find((item) => item.vendor_id === lineItem.vendor_id);
-          const creative = plan.creatives.find((item) => item.creative_id === lineItem.creative_id);
-          const isExpanded = expandedId === lineItem.line_item_id;
+  if (column.type === 'boolean') {
+    return (
+      <input
+        type="checkbox"
+        checked={Boolean(draft)}
+        aria-label={column.label}
+        onChange={(event) => onCommit(event.target.checked)}
+        className="h-4 w-4"
+      />
+    );
+  }
 
-          return (
-            <Fragment key={lineItem.line_item_id}>
-              <tr key={lineItem.line_item_id} className="bg-white hover:bg-slate-50">
-                <Td>
-                  {enableDetails ? (
-                    <button
-                      type="button"
-                      onClick={() => toggle(lineItem.line_item_id)}
-                      className="flex w-full items-center justify-between gap-3 text-left text-sm font-medium text-slate-800"
-                    >
-                      <span>{creative?.ad_name ?? lineItem.line_item_id}</span>
-                      <span className="text-xs text-indigo-600">{isExpanded ? 'Hide' : 'View'} details</span>
-                    </button>
-                  ) : (
-                    <span className="text-sm font-medium text-slate-800">{creative?.ad_name ?? lineItem.line_item_id}</span>
-                  )}
-                </Td>
-                <Td>{campaign?.brand ?? '—'}</Td>
-                <Td>{flight ? formatDateRange(flight.start_date, flight.end_date) : '—'}</Td>
-                <Td>{lineItem.channel}</Td>
-                <Td>{vendor?.name ?? '—'}</Td>
-                <Td>{`${lineItem.pricing_model} @ ${lineItem.rate_unit}`}</Td>
-                <Td align="right">{numberFormatter.format(lineItem.units_planned)}</Td>
-                <Td align="right">{currencyFormatter.format(lineItem.cost_planned)}</Td>
-              </tr>
-              {enableDetails && isExpanded ? (
-                <tr>
-                  <Td colSpan={8} className="bg-slate-50">
-                    <LineItemDetails plan={plan} lineItem={lineItem} />
-                  </Td>
-                </tr>
-              ) : null}
-            </Fragment>
-          );
-        })}
-      </TBody>
-    </Table>
+  if (column.type === 'enum' && column.enum) {
+    return (
+      <Select
+        aria-label={column.label}
+        value={String(draft ?? '')}
+        onChange={(event) => {
+          setDraft(event.currentTarget.value);
+          onCommit(event.currentTarget.value);
+        }}
+      >
+        {column.enum.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </Select>
+    );
+  }
+
+  const inputType = column.type === 'date' ? 'date' : 'text';
+  const step = column.type === 'number' || column.type === 'currency' || column.type === 'percent' ? 'any' : undefined;
+
+  return (
+    <input
+      type={column.type === 'number' || column.type === 'currency' || column.type === 'percent' ? 'number' : inputType}
+      value={typeof draft === 'number' ? Number.isFinite(draft) ? draft : '' : String(draft ?? '')}
+      step={step}
+      aria-label={column.label}
+      onBlur={handleBlur}
+      onChange={(event) => {
+        const nextValue =
+          column.type === 'number' || column.type === 'currency' || column.type === 'percent'
+            ? Number(event.target.value)
+            : event.target.value;
+        setDraft(nextValue as typeof draft);
+      }}
+      className="w-full rounded-md border border-slate-300 px-2 py-1 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+    />
   );
 }

--- a/src/components/ExportDialog.tsx
+++ b/src/components/ExportDialog.tsx
@@ -1,11 +1,14 @@
-import { useState } from 'react';
-import type { Plan } from '@/lib/schemas';
+import { Fragment, useMemo, useState } from 'react';
+import type { Channel, Plan } from '@/lib/schemas';
 import { Modal } from '@/ui/Modal';
 import { Button } from '@/ui/Button';
 import { blockPlanTemplates } from '@/exporters/blockPlan/templates';
 import { buildPdf } from '@/exporters/blockPlan/pdf';
 import { buildExcelWorkbook } from '@/exporters/blockPlan/excel';
 import { exportFilename } from '@/exporters/blockPlan/common';
+import { enumerateWeeks, formatDateRange, toIsoDate } from '@/lib/date';
+import { currencyFormatter } from '@/lib/formatters';
+import clsx from 'clsx';
 
 function downloadBlob(filename: string, blob: Blob) {
   const link = document.createElement('a');
@@ -13,6 +16,170 @@ function downloadBlob(filename: string, blob: Blob) {
   link.download = filename;
   link.click();
   setTimeout(() => URL.revokeObjectURL(link.href), 0);
+}
+
+type BlockPlanRow = {
+  lineItemId: string;
+  channel: Channel;
+  label: string;
+  flightRange: string;
+  activeWeeks: Set<string>;
+  startTimestamp: number;
+  totalCost: number;
+};
+
+function BlockPlanMatrix({ plan }: { plan: Plan }) {
+  const { weeks, groups } = useMemo(() => buildBlockPlan(plan), [plan]);
+
+  if (weeks.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-600">
+        No flightings scheduled yet. Add line items to populate the block plan preview.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-semibold text-slate-800">Block plan preview</h3>
+          <p className="text-xs text-slate-500">Weeks run Sunday through Saturday. Highlighted cells indicate planned activity.</p>
+        </div>
+        <div className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
+          {weeks.length} weeks
+        </div>
+      </div>
+      <div className="overflow-auto rounded-lg border border-slate-200">
+        <table className="min-w-full border-collapse text-xs text-slate-700">
+          <thead className="bg-slate-100 text-[0.7rem] uppercase tracking-wide text-slate-500">
+            <tr>
+              <th className="w-64 px-3 py-2 text-left">Channel / Flight</th>
+              {weeks.map((week) => (
+                <th key={week.key} className="px-3 py-2 text-center font-medium">
+                  {formatDateRange(toIsoDate(week.start), toIsoDate(week.end))}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from(groups.entries()).map(([channel, rows]) => {
+              const channelTotal = rows.reduce((sum, row) => sum + row.totalCost, 0);
+              return (
+                <Fragment key={channel}>
+                  <tr className="bg-slate-50">
+                    <th colSpan={weeks.length + 1} className="px-3 py-2 text-left text-slate-700">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <span className="font-semibold">{channel.replace(/_/g, ' ')}</span>
+                        <span className="text-xs text-slate-500">
+                          {currencyFormatter.format(channelTotal)} planned
+                        </span>
+                      </div>
+                    </th>
+                  </tr>
+                  {rows.map((row) => (
+                    <tr key={row.lineItemId} className="border-b border-slate-100">
+                      <th className="bg-white px-3 py-2 text-left font-medium text-slate-700">
+                        <div className="space-y-1">
+                          <span>{row.label}</span>
+                          <span className="block text-[0.7rem] text-slate-500">{row.flightRange}</span>
+                        </div>
+                      </th>
+                      {weeks.map((week) => {
+                        const active = row.activeWeeks.has(week.key);
+                        const cellLabel = `${row.label} ${active ? 'in market' : 'dark'} ${formatDateRange(
+                          toIsoDate(week.start),
+                          toIsoDate(week.end),
+                        )}`;
+                        return (
+                          <td
+                            key={`${row.lineItemId}-${week.key}`}
+                            className={clsx('px-3 py-2 text-center align-middle', {
+                              'bg-indigo-100 font-semibold text-indigo-900': active,
+                              'text-slate-400': !active,
+                            })}
+                            aria-label={cellLabel}
+                          >
+                            {active ? '●' : '–'}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function buildBlockPlan(plan: Plan) {
+  const flightsById = new Map(plan.flights.map((flight) => [flight.flight_id, flight]));
+  const vendorsById = new Map(plan.vendors.map((vendor) => [vendor.vendor_id, vendor]));
+
+  let earliest: string | null = null;
+  let latest: string | null = null;
+
+  const rows: BlockPlanRow[] = [];
+
+  for (const item of plan.lineItems) {
+    const flight = flightsById.get(item.flight_id);
+    if (!flight) continue;
+
+    const periods =
+      flight.active_periods_json && flight.active_periods_json.length > 0
+        ? flight.active_periods_json
+        : [{ start: flight.start_date, end: flight.end_date }];
+
+    for (const period of periods) {
+      if (!earliest || new Date(period.start) < new Date(earliest)) {
+        earliest = period.start;
+      }
+      if (!latest || new Date(period.end) > new Date(latest)) {
+        latest = period.end;
+      }
+    }
+
+    const activeWeeks = new Set<string>();
+    periods.forEach((period) => {
+      enumerateWeeks(new Date(period.start), new Date(period.end)).forEach((week) => {
+        activeWeeks.add(week.key);
+      });
+    });
+
+    rows.push({
+      lineItemId: item.line_item_id,
+      channel: item.channel,
+      label: vendorsById.get(item.vendor_id)?.name ?? item.line_item_id,
+      flightRange: formatDateRange(flight.start_date, flight.end_date),
+      activeWeeks,
+      startTimestamp: new Date(flight.start_date).getTime(),
+      totalCost: item.cost_planned,
+    });
+  }
+
+  if (!earliest || !latest) {
+    return { weeks: [] as ReturnType<typeof enumerateWeeks>, groups: new Map<Channel, BlockPlanRow[]>() };
+  }
+
+  const weeks = enumerateWeeks(new Date(earliest), new Date(latest));
+  const groups = new Map<Channel, BlockPlanRow[]>();
+
+  for (const row of rows) {
+    const bucket = groups.get(row.channel) ?? [];
+    bucket.push(row);
+    groups.set(row.channel, bucket);
+  }
+
+  groups.forEach((list, channel) => {
+    list.sort((a, b) => a.startTimestamp - b.startTimestamp);
+    groups.set(channel, list);
+  });
+
+  return { weeks, groups };
 }
 
 export function ExportDialog({ plan, open, onClose }: { plan: Plan; open: boolean; onClose: () => void }) {
@@ -59,22 +226,31 @@ export function ExportDialog({ plan, open, onClose }: { plan: Plan; open: boolea
         </div>
       }
     >
-      <div className="space-y-3">
+      <div className="space-y-6">
         <p className="text-sm text-slate-600">
           Plan exports include status, approver, pacing warnings, and a block plan matrix. Draft plans include a watermark.
         </p>
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
-          {blockPlanTemplates.map((template) => (
-            <button
-              key={template.id}
-              type="button"
-              onClick={() => setSelectedTemplate(template)}
-              className={`rounded-lg border p-3 text-left text-sm shadow-sm transition hover:border-indigo-400 ${selectedTemplate.id === template.id ? 'border-indigo-500 bg-indigo-50' : 'border-slate-200 bg-white'}`}
-            >
-              <div className="font-semibold text-slate-700">{template.name}</div>
-              <div className="mt-1 text-xs text-slate-500">{template.description}</div>
-            </button>
-          ))}
+        <BlockPlanMatrix plan={plan} />
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold text-slate-800">Export templates</h3>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+            {blockPlanTemplates.map((template) => (
+              <button
+                key={template.id}
+                type="button"
+                onClick={() => setSelectedTemplate(template)}
+                className={clsx(
+                  'rounded-lg border p-3 text-left text-sm shadow-sm transition hover:border-indigo-400',
+                  selectedTemplate.id === template.id
+                    ? 'border-indigo-500 bg-indigo-50'
+                    : 'border-slate-200 bg-white',
+                )}
+              >
+                <div className="font-semibold text-slate-700">{template.name}</div>
+                <div className="mt-1 text-xs text-slate-500">{template.description}</div>
+              </button>
+            ))}
+          </div>
         </div>
       </div>
     </Modal>

--- a/src/components/FlightDetailsModal.tsx
+++ b/src/components/FlightDetailsModal.tsx
@@ -1,0 +1,171 @@
+import { formatDate, formatDateRange } from '@/lib/date';
+import { currencyFormatter, numberFormatter } from '@/lib/formatters';
+import { Modal } from '@/ui/Modal';
+import { Button } from '@/ui/Button';
+import type { ChannelFlighting } from '@/api/plans';
+import { extensionKeyByChannel } from '@/lib/channelExtensions';
+
+type FlightDetailsModalProps = {
+  flighting: ChannelFlighting | null;
+  open: boolean;
+  onClose: () => void;
+};
+
+type Row = { label: string; value: string };
+
+type Section = { title: string; rows: Row[] };
+
+export function FlightDetailsModal({ flighting, open, onClose }: FlightDetailsModalProps) {
+  if (!flighting || !flighting.lineItem) {
+    return null;
+  }
+
+  const { lineItem, flight, vendor, audience, tracking, creative } = flighting;
+  const extensionKey = extensionKeyByChannel[lineItem.channel];
+  const extension = extensionKey
+    ? (lineItem[extensionKey] as Record<string, unknown> | undefined)
+    : undefined;
+
+  const core: Row[] = compact([
+    { label: 'Line item ID', value: lineItem.line_item_id },
+    { label: 'Channel', value: lineItem.channel.replace(/_/g, ' ') },
+    vendor?.name ? { label: 'Vendor', value: vendor.name } : null,
+    creative?.ad_name ? { label: 'Creative', value: creative.ad_name } : null,
+    flight
+      ? {
+          label: 'Flight window',
+          value: `${formatDate(flight.start_date)} – ${formatDate(flight.end_date)}`,
+        }
+      : null,
+    flight?.active_periods_json?.length
+      ? {
+          label: 'Active periods',
+          value: flight.active_periods_json
+            .map((period) => formatDateRange(period.start, period.end))
+            .join(', '),
+        }
+      : null,
+    { label: 'Planned cost', value: currencyFormatter.format(lineItem.cost_planned) },
+  ]);
+
+  const targeting: Row[] = compact([
+    audience?.definition ? { label: 'Audience', value: audience.definition } : null,
+    audience?.geo ? { label: 'Geography', value: audience.geo } : null,
+    lineItem.goal_type ? { label: 'Goal type', value: lineItem.goal_type.replace(/_/g, ' ') } : null,
+  ]);
+
+  const buying: Row[] = compact([
+    { label: 'Pricing model', value: lineItem.pricing_model },
+    {
+      label: 'Rate',
+      value: formatRate(lineItem.rate_numeric, lineItem.rate_unit),
+    },
+    { label: 'Units planned', value: numberFormatter.format(lineItem.units_planned) },
+    lineItem.pacing ? { label: 'Pacing', value: lineItem.pacing } : null,
+  ]);
+
+  const trackingRows: Row[] = compact([
+    tracking?.ad_server ? { label: 'Ad server', value: tracking.ad_server } : null,
+    tracking?.verification_vendor
+      ? { label: 'Verification', value: tracking.verification_vendor }
+      : null,
+    tracking?.conversion_source
+      ? { label: 'Conversion source', value: tracking.conversion_source }
+      : null,
+    lineItem.notes ? { label: 'Notes', value: lineItem.notes } : null,
+  ]);
+
+  const extensionRows: Row[] = extension
+    ? Object.entries(extension).map(([key, value]) => ({
+        label: startCase(key.replace(/_ext$/, '')),
+        value: formatValue(value),
+      }))
+    : [];
+
+  const sections: Section[] = [
+    { title: 'Core', rows: core },
+    { title: 'Targeting', rows: targeting },
+    { title: 'Buying & Units', rows: buying },
+    { title: 'Tracking & Notes', rows: trackingRows },
+  ];
+
+  if (extensionRows.length > 0) {
+    sections.push({ title: 'Channel extension', rows: extensionRows });
+  }
+
+  return (
+    <Modal
+      title={`${lineItem.channel.replace(/_/g, ' ')} flighting details`}
+      description="Review the structured payload powering this placement."
+      open={open}
+      onClose={onClose}
+      footer={
+        <div className="flex justify-end">
+          <Button onClick={onClose}>Close</Button>
+        </div>
+      }
+    >
+      <div className="space-y-6">
+        {sections.map((section) =>
+          section.rows.length > 0 ? (
+            <section key={section.title} className="space-y-3">
+              <h3 className="text-sm font-semibold text-slate-800">{section.title}</h3>
+              <dl className="grid grid-cols-1 gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
+                {section.rows.map((row) => (
+                  <div key={`${section.title}-${row.label}`} className="space-y-1">
+                    <dt className="text-xs uppercase tracking-wide text-slate-500">{row.label}</dt>
+                    <dd className="text-slate-900">{row.value}</dd>
+                  </div>
+                ))}
+              </dl>
+            </section>
+          ) : null,
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+function compact<T>(items: (T | null | undefined)[]): T[] {
+  return items.filter((item): item is T => item != null);
+}
+
+function formatRate(rate: number, unit: string) {
+  if (Number.isNaN(rate)) return '—';
+  const formatter = new Intl.NumberFormat('en-AU', {
+    style: 'currency',
+    currency: 'AUD',
+    maximumFractionDigits: 2,
+  });
+  const formatted = formatter.format(rate);
+  return `${formatted} ${unit}`;
+}
+
+function startCase(value: string) {
+  return value
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (match) => match.toUpperCase())
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function formatValue(value: unknown): string {
+  if (value == null) return '—';
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (typeof value === 'number') return numberFormatter.format(value);
+  if (typeof value === 'string') {
+    if (/^\d{4}-\d{2}-\d{2}/.test(value)) {
+      return formatDate(value);
+    }
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => formatValue(entry)).join(', ');
+  }
+  if (typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>)
+      .map(([key, entry]) => `${startCase(key)}: ${formatValue(entry)}`)
+      .join('; ');
+  }
+  return String(value);
+}

--- a/src/components/MediaPlanOverviewCard.tsx
+++ b/src/components/MediaPlanOverviewCard.tsx
@@ -1,0 +1,80 @@
+import { useMemo } from 'react';
+import type { Plan } from '@/lib/schemas';
+import { Card } from '@/ui/Card';
+import { Button } from '@/ui/Button';
+import { currencyFormatter } from '@/lib/formatters';
+import { formatDate } from '@/lib/date';
+
+type MediaPlanOverviewCardProps = {
+  plan: Plan;
+  onEdit?: () => void;
+};
+
+export function MediaPlanOverviewCard({ plan, onEdit }: MediaPlanOverviewCardProps) {
+  const { totalCost, startDate, endDate } = useMemo(() => {
+    const total = plan.lineItems.reduce((sum, item) => sum + item.cost_planned, 0);
+    const fallbackStart = plan.flights.length
+      ? plan.flights.map((flight) => flight.start_date).reduce((min, current) => (current < min ? current : min))
+      : null;
+    const fallbackEnd = plan.flights.length
+      ? plan.flights.map((flight) => flight.end_date).reduce((max, current) => (current > max ? current : max))
+      : null;
+
+    return {
+      totalCost: total,
+      startDate: plan.start_date ?? fallbackStart,
+      endDate: plan.end_date ?? fallbackEnd,
+    };
+  }, [plan.end_date, plan.flights, plan.lineItems, plan.start_date]);
+
+  return (
+    <section aria-labelledby="plan-overview-heading">
+      <Card className="flex flex-col gap-6">
+        <header className="flex flex-col gap-2 border-b border-slate-200 pb-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-slate-500">Media Plan</p>
+            <h1 id="plan-overview-heading" className="text-2xl font-semibold text-slate-900 sm:text-3xl">
+              {plan.meta.name}
+            </h1>
+            <p className="mt-1 text-sm text-slate-600">Client: {plan.meta.client}</p>
+          </div>
+          {onEdit ? (
+            <Button variant="secondary" onClick={onEdit} aria-label="Edit plan">
+              Edit plan
+            </Button>
+          ) : null}
+        </header>
+        <dl className="grid grid-cols-1 gap-x-8 gap-y-4 text-sm sm:grid-cols-2 lg:grid-cols-3">
+          <div>
+            <dt className="font-medium text-slate-600">Plan code</dt>
+            <dd className="mt-1 text-slate-900">{plan.meta.code}</dd>
+          </div>
+          <div>
+            <dt className="font-medium text-slate-600">Status</dt>
+            <dd className="mt-1 inline-flex items-center rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-slate-700">
+              {plan.status}
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-slate-600">Total cost</dt>
+            <dd className="mt-1 text-slate-900">{currencyFormatter.format(totalCost)}</dd>
+          </div>
+          <div>
+            <dt className="font-medium text-slate-600">Date range</dt>
+            <dd className="mt-1 text-slate-900">
+              {startDate && endDate ? `${formatDate(startDate)} – ${formatDate(endDate)}` : 'To be scheduled'}
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-slate-600">Owner</dt>
+            <dd className="mt-1 text-slate-900">{plan.owner}</dd>
+          </div>
+          <div>
+            <dt className="font-medium text-slate-600">Approver</dt>
+            <dd className="mt-1 text-slate-900">{plan.approver ?? 'Unassigned'}</dd>
+          </div>
+        </dl>
+      </Card>
+    </section>
+  );
+}

--- a/src/components/PlanCard.tsx
+++ b/src/components/PlanCard.tsx
@@ -1,7 +1,17 @@
 import { Button } from '@/ui/Button';
 import { Card } from '@/ui/Card';
 import type { Plan } from '@/lib/schemas';
-import { formatDate } from '@/lib/date';
+import { formatDate, formatDateRange } from '@/lib/date';
+import { currencyFormatter } from '@/lib/formatters';
+
+function getDateRange(plan: Plan) {
+  if (plan.flights.length === 0) return 'Set flight dates to reveal the schedule';
+  const starts = plan.flights.map((flight) => flight.start_date);
+  const ends = plan.flights.map((flight) => flight.end_date);
+  const minStart = starts.reduce((min, current) => (current < min ? current : min), starts[0]);
+  const maxEnd = ends.reduce((max, current) => (current > max ? current : max), ends[0]);
+  return formatDateRange(minStart, maxEnd);
+}
 
 export function PlanCard({
   plan,
@@ -18,7 +28,12 @@ export function PlanCard({
     <Card className="flex flex-col gap-5">
       <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div className="space-y-2">
-          <h3 className="text-xl font-semibold text-slate-900">{plan.meta.name}</h3>
+          <div className="flex flex-col gap-1">
+            <span className="inline-flex items-center rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700">
+              {plan.meta.client}
+            </span>
+            <h3 className="text-xl font-semibold text-slate-900">{plan.meta.name}</h3>
+          </div>
           <div className="flex flex-wrap items-center gap-2 text-xs font-medium text-slate-500">
             <span className="rounded-full bg-indigo-50 px-2.5 py-1 text-xs font-semibold text-indigo-600">
               v{plan.meta.version}
@@ -28,6 +43,16 @@ export function PlanCard({
             </span>
             <span className="text-slate-400">{plan.meta.code}</span>
           </div>
+          <dl className="grid grid-cols-1 gap-2 text-xs text-slate-500 sm:grid-cols-2">
+            <div>
+              <dt className="uppercase tracking-wide">Plan window</dt>
+              <dd className="text-sm font-medium text-slate-800">{getDateRange(plan)}</dd>
+            </div>
+            <div>
+              <dt className="uppercase tracking-wide">Working budget</dt>
+              <dd className="text-sm font-medium text-slate-800">{currencyFormatter.format(plan.goal.budget)}</dd>
+            </div>
+          </dl>
         </div>
         <span className="inline-flex items-center rounded-full bg-slate-50 px-3 py-1 text-xs font-medium text-slate-500">
           Updated {formatDate(plan.lastModified)}

--- a/src/components/PlanList.tsx
+++ b/src/components/PlanList.tsx
@@ -1,7 +1,31 @@
 import type { Plan } from '@/lib/schemas';
 import { PlanCard } from './PlanCard';
+import { Table, THead, TBody, Th, Td } from '@/ui/Table';
+import { currencyFormatter } from '@/lib/formatters';
+import { formatDate, formatDateRange } from '@/lib/date';
+import { Button } from '@/ui/Button';
 
-export function PlanList({
+export type PlanListView = 'grid' | 'list';
+
+function getPlanDateRange(plan: Plan) {
+  if (plan.flights.length === 0) return 'Not scheduled';
+  const starts = plan.flights.map((flight) => flight.start_date);
+  const ends = plan.flights.map((flight) => flight.end_date);
+  const minStart = starts.reduce((min, current) => (current < min ? current : min), starts[0]);
+  const maxEnd = ends.reduce((max, current) => (current > max ? current : max), ends[0]);
+  return formatDateRange(minStart, maxEnd);
+}
+
+function getCreatedEvent(plan: Plan) {
+  const created = plan.audit.find((event) => event.action === 'created');
+  return created ?? plan.audit[0];
+}
+
+function getLastEvent(plan: Plan) {
+  return plan.audit[plan.audit.length - 1];
+}
+
+function GridView({
   plans,
   onOpen,
   onReview,
@@ -12,10 +36,6 @@ export function PlanList({
   onReview: (id: string) => void;
   onDuplicate: (id: string) => void;
 }) {
-  if (plans.length === 0) {
-    return <p className="text-sm text-slate-500">No plans yet. Create one to get started.</p>;
-  }
-
   return (
     <div className="grid grid-cols-1 gap-5 sm:gap-6 md:grid-cols-2">
       {plans.map((plan) => (
@@ -29,4 +49,103 @@ export function PlanList({
       ))}
     </div>
   );
+}
+
+function ListView({
+  plans,
+  onOpen,
+  onReview,
+  onDuplicate,
+}: {
+  plans: Plan[];
+  onOpen: (id: string) => void;
+  onReview: (id: string) => void;
+  onDuplicate: (id: string) => void;
+}) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+      <Table>
+        <THead>
+          <tr>
+            <Th align="left">Plan</Th>
+            <Th align="left">Client</Th>
+            <Th align="left">Date range</Th>
+            <Th align="right">Budget</Th>
+            <Th align="left">Status</Th>
+            <Th align="left">Created</Th>
+            <Th align="left">Updated</Th>
+            <Th align="left">Owner</Th>
+            <Th align="left">Updated by</Th>
+            <Th align="right">Actions</Th>
+          </tr>
+        </THead>
+        <TBody>
+          {plans.map((plan) => {
+            const created = getCreatedEvent(plan);
+            const lastEvent = getLastEvent(plan) ?? created;
+            return (
+              <tr key={plan.id} className="bg-white hover:bg-slate-50">
+                <Td>{plan.meta.name}</Td>
+                <Td>{plan.meta.client}</Td>
+                <Td>{getPlanDateRange(plan)}</Td>
+                <Td align="right">{currencyFormatter.format(plan.goal.budget)}</Td>
+                <Td>{plan.status}</Td>
+                <Td>
+                  <div className="flex flex-col">
+                    <span className="text-sm font-medium text-slate-800">{formatDate(created?.timestamp ?? plan.lastModified)}</span>
+                    <span className="text-xs text-slate-500">{created?.actor ?? plan.owner}</span>
+                  </div>
+                </Td>
+                <Td>
+                  <div className="flex flex-col">
+                    <span className="text-sm font-medium text-slate-800">{formatDate(plan.lastModified)}</span>
+                    <span className="text-xs text-slate-500">{lastEvent?.actor ?? plan.owner}</span>
+                  </div>
+                </Td>
+                <Td>{plan.owner}</Td>
+                <Td>{lastEvent?.actor ?? plan.owner}</Td>
+                <Td align="right">
+                  <div className="flex flex-col gap-1 sm:flex-row sm:justify-end">
+                    <Button className="px-3 py-1 text-xs" onClick={() => onOpen(plan.id)}>
+                      Open
+                    </Button>
+                    <Button className="px-3 py-1 text-xs" variant="secondary" onClick={() => onReview(plan.id)}>
+                      Review
+                    </Button>
+                    <Button className="px-3 py-1 text-xs" variant="ghost" onClick={() => onDuplicate(plan.id)}>
+                      Duplicate
+                    </Button>
+                  </div>
+                </Td>
+              </tr>
+            );
+          })}
+        </TBody>
+      </Table>
+    </div>
+  );
+}
+
+export function PlanList({
+  plans,
+  viewMode = 'grid',
+  onOpen,
+  onReview,
+  onDuplicate,
+}: {
+  plans: Plan[];
+  viewMode?: PlanListView;
+  onOpen: (id: string) => void;
+  onReview: (id: string) => void;
+  onDuplicate: (id: string) => void;
+}) {
+  if (plans.length === 0) {
+    return <p className="text-sm text-slate-500">No plans yet. Create one to get started.</p>;
+  }
+
+  if (viewMode === 'list') {
+    return <ListView plans={plans} onOpen={onOpen} onReview={onReview} onDuplicate={onDuplicate} />;
+  }
+
+  return <GridView plans={plans} onOpen={onOpen} onReview={onReview} onDuplicate={onDuplicate} />;
 }

--- a/src/components/PlanTitleBar.tsx
+++ b/src/components/PlanTitleBar.tsx
@@ -7,9 +7,11 @@ import { Input } from '@/ui/Input';
 import { Button } from '@/ui/Button';
 import { useMutatePlan } from '@/api/plans';
 import { useUser, canApprove } from '@/auth/useUser';
+import { formatDateTime } from '@/lib/date';
 
 const metaSchema = z.object({
   name: z.string().min(2, 'Name is required'),
+  client: z.string().min(2, 'Client is required'),
   code: z.string().min(1, 'Code is required'),
 });
 
@@ -37,12 +39,12 @@ export function PlanTitleBar({
 
   const form = useForm<MetaForm>({
     resolver: zodResolver(metaSchema),
-    defaultValues: { name: plan.meta.name, code: plan.meta.code },
+    defaultValues: { name: plan.meta.name, client: plan.meta.client, code: plan.meta.code },
   });
 
   useEffect(() => {
-    form.reset({ name: plan.meta.name, code: plan.meta.code });
-  }, [plan.meta.name, plan.meta.code, form]);
+    form.reset({ name: plan.meta.name, client: plan.meta.client, code: plan.meta.code });
+  }, [plan.meta.name, plan.meta.client, plan.meta.code, form]);
 
   const submitMeta = form.handleSubmit(async (values) => {
     if (editingDisabled) return;
@@ -59,12 +61,18 @@ export function PlanTitleBar({
   const showRevert = plan.status !== 'Draft' && plan.status !== 'Approved';
 
   const nameId = `plan-name-${plan.id}`;
+  const clientId = `plan-client-${plan.id}`;
   const codeId = `plan-code-${plan.id}`;
 
   return (
     <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
       <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
         <div className="flex w-full flex-col gap-4 lg:max-w-xl">
+          <div className="rounded-lg border border-indigo-200 bg-indigo-50 px-4 py-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600">Client</p>
+            <p className="text-lg font-semibold text-indigo-900">{plan.meta.client}</p>
+            <p className="text-xs text-indigo-700">Keep teams aligned by validating the brand you are planning for.</p>
+          </div>
           <form
             className="grid w-full gap-4 sm:grid-cols-3 sm:items-end"
             onSubmit={(event) => event.preventDefault()}
@@ -76,6 +84,18 @@ export function PlanTitleBar({
               <Input
                 {...form.register('name')}
                 id={nameId}
+                onBlur={() => submitMeta()}
+                disabled={editingDisabled}
+                className="w-full"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label htmlFor={clientId} className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                Client
+              </label>
+              <Input
+                {...form.register('client')}
+                id={clientId}
                 onBlur={() => submitMeta()}
                 disabled={editingDisabled}
                 className="w-full"
@@ -99,7 +119,7 @@ export function PlanTitleBar({
               v{plan.meta.version}
             </span>
             <span className="rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-600">{plan.status}</span>
-            <span className="text-slate-400">Last modified {new Date(plan.lastModified).toLocaleString()}</span>
+            <span className="text-slate-400">Last modified {formatDateTime(plan.lastModified)}</span>
           </div>
           <p className="text-xs text-slate-500">Autosaves instantly after each change.</p>
         </div>

--- a/src/components/dialogs/AddChannelDialog.tsx
+++ b/src/components/dialogs/AddChannelDialog.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { Modal } from '@/ui/Modal';
+import { Button } from '@/ui/Button';
+import { Select } from '@/ui/Select';
+import { channelEnum, type Channel } from '@/lib/schemas';
+
+export function AddChannelDialog({
+  open,
+  busy,
+  onClose,
+  onAdd,
+}: {
+  open: boolean;
+  busy: boolean;
+  onClose: () => void;
+  onAdd: (channel: Channel) => Promise<void> | void;
+}) {
+  const [selected, setSelected] = useState<Channel>(channelEnum.options[0]);
+
+  useEffect(() => {
+    if (open) {
+      setSelected(channelEnum.options[0]);
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title="Add a channel"
+      description="Create a new channel row and scaffold the required flighting details."
+      footer={
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            disabled={busy}
+            onClick={() => {
+              void onAdd(selected);
+            }}
+          >
+            Add channel
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-4">
+        <p className="text-sm text-slate-600">
+          Channels determine the fields shown in the line item form and the columns rendered in the flighting table.
+        </p>
+        <label className="flex flex-col gap-2 text-sm text-slate-700">
+          <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">Channel</span>
+          <Select value={selected} onChange={(event) => setSelected(event.currentTarget.value as Channel)}>
+            {channelEnum.options.map((channel) => (
+              <option key={channel} value={channel}>
+                {channel.replace(/_/g, ' ')}
+              </option>
+            ))}
+          </Select>
+        </label>
+        <p className="text-xs text-slate-500">
+          Channel-specific extension fields will be pre-filled with placeholder values so planners can refine them later.
+        </p>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/dialogs/FlightingScheduleDialog.tsx
+++ b/src/components/dialogs/FlightingScheduleDialog.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { ChannelFlighting } from '@/api/plans';
+import { Modal } from '@/ui/Modal';
+import { Button } from '@/ui/Button';
+import { addDays, enumerateWeeks, formatDateRange, toIsoDate } from '@/lib/date';
+
+export function FlightingScheduleDialog({
+  flighting,
+  open,
+  onClose,
+  onSave,
+}: {
+  flighting: ChannelFlighting | null;
+  open: boolean;
+  onClose: () => void;
+  onSave: (flightId: string, periods: { start: string; end: string }[]) => Promise<void> | void;
+}) {
+  const flight = flighting?.flight;
+  const [selectedWeeks, setSelectedWeeks] = useState<Set<string>>(new Set());
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!open || !flight) return;
+    const initial = new Set<string>();
+    const basePeriods =
+      flight.active_periods_json && flight.active_periods_json.length > 0
+        ? flight.active_periods_json
+        : [{ start: flight.start_date, end: flight.end_date }];
+    for (const period of basePeriods) {
+      const weeks = enumerateWeeks(new Date(period.start), new Date(period.end));
+      weeks.forEach((week) => initial.add(week.key));
+    }
+    setSelectedWeeks(initial);
+  }, [flight, open]);
+
+  const weeks = useMemo(() => {
+    if (!flight) return [] as ReturnType<typeof enumerateWeeks>;
+    return enumerateWeeks(new Date(flight.start_date), new Date(flight.end_date));
+  }, [flight]);
+
+  if (!open || !flighting || !flight) {
+    return null;
+  }
+
+  const handleToggle = (weekKey: string) => {
+    setSelectedWeeks((prev) => {
+      const next = new Set(prev);
+      if (next.has(weekKey)) {
+        next.delete(weekKey);
+      } else {
+        next.add(weekKey);
+      }
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    if (selectedWeeks.size === 0) return;
+    setSaving(true);
+    const periods = derivePeriods(weeks, selectedWeeks, flight.start_date, flight.end_date);
+    try {
+      await onSave(flight.flight_id, periods);
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const vendorName = flighting.vendor?.name ?? 'Flighting';
+  const channelName = flighting.lineItem.channel.replace(/_/g, ' ');
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={`Schedule ${vendorName}`}
+      description={`Select the weeks ${channelName} should be in market. Unselected weeks will be treated as a dark period.`}
+      footer={
+        <div className="flex justify-between gap-2">
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button disabled={saving || selectedWeeks.size === 0} onClick={handleSave}>
+            Save schedule
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-3">
+        <p className="text-sm text-slate-600">
+          Toggle weeks to reflect pulsing or hiatus periods. Flight start and end dates remain unchanged.
+        </p>
+        <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {weeks.map((week) => {
+            const weekStart = new Date(Math.max(week.start.getTime(), new Date(flight.start_date).getTime()));
+            const weekEnd = new Date(Math.min(week.end.getTime(), new Date(flight.end_date).getTime()));
+            const label = formatDateRange(toIsoDate(weekStart), toIsoDate(weekEnd));
+            const checked = selectedWeeks.has(week.key);
+            return (
+              <li key={week.key}>
+                <label className="flex cursor-pointer items-center gap-3 rounded-lg border border-slate-200 bg-white px-3 py-2 shadow-sm transition hover:border-indigo-400">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                    checked={checked}
+                    onChange={() => handleToggle(week.key)}
+                  />
+                  <span className="text-sm font-medium text-slate-700">{label}</span>
+                </label>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </Modal>
+  );
+}
+
+function derivePeriods(
+  weeks: ReturnType<typeof enumerateWeeks>,
+  selection: Set<string>,
+  flightStart: string,
+  flightEnd: string,
+) {
+  const activeWeeks = weeks
+    .filter((week) => selection.has(week.key))
+    .sort((a, b) => a.start.getTime() - b.start.getTime());
+
+  const periods: { start: string; end: string }[] = [];
+  if (activeWeeks.length === 0) return periods;
+
+  let currentStart = new Date(activeWeeks[0].start);
+  let currentEnd = new Date(activeWeeks[0].end);
+
+  for (let index = 1; index < activeWeeks.length; index += 1) {
+    const week = activeWeeks[index];
+    const previousEndPlusOne = addDays(currentEnd, 1);
+    if (week.start.getTime() <= previousEndPlusOne.getTime()) {
+      currentEnd = new Date(week.end);
+    } else {
+      periods.push({
+        start: toIsoDate(clampDate(currentStart, new Date(flightStart), new Date(flightEnd))),
+        end: toIsoDate(clampDate(currentEnd, new Date(flightStart), new Date(flightEnd))),
+      });
+      currentStart = new Date(week.start);
+      currentEnd = new Date(week.end);
+    }
+  }
+
+  periods.push({
+    start: toIsoDate(clampDate(currentStart, new Date(flightStart), new Date(flightEnd))),
+    end: toIsoDate(clampDate(currentEnd, new Date(flightStart), new Date(flightEnd))),
+  });
+
+  return periods;
+}
+
+function clampDate(value: Date, min: Date, max: Date) {
+  return new Date(Math.min(Math.max(value.getTime(), min.getTime()), max.getTime()));
+}

--- a/src/config/channelTableConfig.ts
+++ b/src/config/channelTableConfig.ts
@@ -1,0 +1,433 @@
+import type { Channel } from '@/lib/schemas';
+
+type ColumnType =
+  | 'text'
+  | 'enum'
+  | 'date'
+  | 'currency'
+  | 'number'
+  | 'percent'
+  | 'boolean';
+
+type ColumnSpec = {
+  id: string;
+  label: string;
+  type: ColumnType;
+  width?: number;
+  editable?: boolean;
+  required?: boolean;
+  enum?: string[];
+  align?: 'left' | 'right' | 'center';
+  precision?: number;
+};
+
+type ChannelColumnConfig = Record<Channel, ColumnSpec[]>;
+
+type HierarchicalTableConfig = {
+  topLevelColumns: ColumnSpec[];
+  flightingCommonColumns: ColumnSpec[];
+  channelSpecificColumns: ChannelColumnConfig;
+};
+
+const PricingModelOptions = {
+  CPM: 'CPM',
+  CPC: 'CPC',
+  CPA: 'CPA',
+  CPP: 'CPP',
+  CPT: 'CPT',
+  Fixed: 'Fixed',
+  Hybrid: 'Hybrid',
+} as const;
+
+const baseCommonColumns: ColumnSpec[] = [
+  {
+    id: 'vendor_platform',
+    label: 'Vendor / Platform',
+    type: 'text',
+    width: 224,
+    editable: true,
+    required: true,
+  },
+  {
+    id: 'start_date',
+    label: 'Start Date',
+    type: 'date',
+    width: 140,
+    editable: true,
+    required: true,
+  },
+  {
+    id: 'end_date',
+    label: 'End Date',
+    type: 'date',
+    width: 140,
+    editable: true,
+    required: true,
+  },
+  {
+    id: 'pricing_model',
+    label: 'Pricing Model',
+    type: 'enum',
+    enum: Object.values(PricingModelOptions),
+    width: 160,
+    editable: true,
+    required: true,
+  },
+  {
+    id: 'rate',
+    label: 'Rate',
+    type: 'currency',
+    width: 140,
+    editable: true,
+    required: true,
+    align: 'right',
+  },
+  {
+    id: 'units_planned',
+    label: 'Units Planned',
+    type: 'number',
+    width: 160,
+    editable: true,
+    align: 'right',
+  },
+  {
+    id: 'planned_cost',
+    label: 'Planned Cost',
+    type: 'currency',
+    width: 160,
+    editable: true,
+    required: true,
+    align: 'right',
+  },
+  {
+    id: 'primary_kpi',
+    label: 'Primary KPI',
+    type: 'text',
+    width: 160,
+    editable: true,
+  },
+  {
+    id: 'audience_label',
+    label: 'Audience',
+    type: 'text',
+    width: 200,
+    editable: true,
+  },
+];
+
+const channelSpecificColumns: ChannelColumnConfig = {
+  OOH: [
+    { id: 'owner', label: 'Owner', type: 'text', width: 160, editable: true },
+    { id: 'format', label: 'Format', type: 'text', width: 160, editable: true },
+    { id: 'digital', label: 'Digital', type: 'boolean', width: 120, editable: true },
+    { id: 'sites', label: 'Sites', type: 'number', width: 120, editable: true, align: 'right' },
+    { id: 'sov_or_loop', label: 'SOV / Loop', type: 'text', width: 150, editable: true },
+    { id: 'weekly_imps', label: 'Weekly Imps', type: 'number', width: 160, editable: true, align: 'right' },
+    {
+      id: 'facing_orientation',
+      label: 'Facing / Orientation',
+      type: 'text',
+      width: 180,
+      editable: true,
+    },
+    { id: 'location', label: 'Location', type: 'text', width: 200, editable: true },
+    {
+      id: 'production_install_fees',
+      label: 'Production / Install Fees',
+      type: 'currency',
+      width: 200,
+      editable: true,
+      align: 'right',
+    },
+  ],
+  TV: [
+    { id: 'network_region', label: 'Network / Region', type: 'text', width: 200, editable: true },
+    { id: 'program_or_daypart', label: 'Program / Daypart', type: 'text', width: 200, editable: true },
+    {
+      id: 'spot_length_sec',
+      label: 'Spot Length (sec)',
+      type: 'number',
+      width: 160,
+      editable: true,
+      align: 'right',
+    },
+    { id: 'spots', label: 'Spots', type: 'number', width: 140, editable: true, align: 'right' },
+    { id: 'buy_unit', label: 'Buy Unit', type: 'text', width: 160, editable: true },
+    { id: 'target_demo', label: 'Target Demo', type: 'text', width: 180, editable: true },
+    { id: 'est_tarps', label: 'Est. TARPs', type: 'number', width: 160, editable: true, align: 'right', precision: 1 },
+  ],
+  BVOD_CTV: [
+    { id: 'platform', label: 'Platform', type: 'text', width: 160, editable: true },
+    { id: 'buy_type', label: 'Buy Type', type: 'text', width: 160, editable: true },
+    {
+      id: 'device_mix_ctv_pct',
+      label: 'Device Mix (CTV%)',
+      type: 'percent',
+      width: 180,
+      editable: true,
+      align: 'right',
+      precision: 1,
+    },
+    { id: 'pod_position', label: 'Pod Position', type: 'enum', width: 160, editable: true, enum: ['Pre', 'Mid', 'Post'] },
+    {
+      id: 'ad_duration_sec',
+      label: 'Ad Duration (sec)',
+      type: 'number',
+      width: 160,
+      editable: true,
+      align: 'right',
+    },
+    {
+      id: 'vcr_goal_pct',
+      label: 'VCR Goal (%)',
+      type: 'percent',
+      width: 160,
+      editable: true,
+      align: 'right',
+      precision: 1,
+    },
+    {
+      id: 'viewability_standard',
+      label: 'Viewability Std',
+      type: 'text',
+      width: 200,
+      editable: true,
+    },
+  ],
+  Digital_Display: [
+    { id: 'exchange_or_deal', label: 'Exchange / Deal', type: 'text', width: 200, editable: true },
+    { id: 'inventory_type', label: 'Inventory', type: 'enum', width: 160, editable: true, enum: ['Display', 'Outstream'] },
+    { id: 'creative_sizes', label: 'Sizes', type: 'text', width: 200, editable: true },
+    { id: 'targeting_short', label: 'Targeting', type: 'text', width: 180, editable: true },
+    {
+      id: 'viewability_goal_pct',
+      label: 'Viewability Goal (%)',
+      type: 'percent',
+      width: 200,
+      editable: true,
+      align: 'right',
+      precision: 1,
+    },
+    { id: 'brand_safety_tier', label: 'Brand Safety', type: 'text', width: 180, editable: true },
+  ],
+  Digital_Video: [
+    { id: 'exchange_or_deal', label: 'Exchange / Deal', type: 'text', width: 200, editable: true },
+    {
+      id: 'inventory_type',
+      label: 'Inventory',
+      type: 'enum',
+      width: 160,
+      editable: true,
+      enum: ['Instream', 'Outstream'],
+    },
+    {
+      id: 'ad_duration_sec',
+      label: 'Duration (sec)',
+      type: 'number',
+      width: 160,
+      editable: true,
+      align: 'right',
+    },
+    { id: 'pod_or_position', label: 'Pod / Position', type: 'text', width: 180, editable: true },
+    {
+      id: 'vcr_goal_pct',
+      label: 'VCR Goal (%)',
+      type: 'percent',
+      width: 160,
+      editable: true,
+      align: 'right',
+      precision: 1,
+    },
+    { id: 'brand_safety_tier', label: 'Brand Safety', type: 'text', width: 180, editable: true },
+  ],
+  Social: [
+    { id: 'platform', label: 'Platform', type: 'text', width: 160, editable: true },
+    { id: 'objective', label: 'Objective', type: 'text', width: 180, editable: true },
+    { id: 'format', label: 'Format', type: 'text', width: 160, editable: true },
+    { id: 'optimization_event', label: 'Optimization', type: 'text', width: 200, editable: true },
+    { id: 'attribution_window', label: 'Attribution Window', type: 'text', width: 200, editable: true },
+    { id: 'frequency_cap', label: 'Freq Cap', type: 'text', width: 160, editable: true },
+  ],
+  Search: [
+    { id: 'engine', label: 'Engine', type: 'text', width: 160, editable: true },
+    { id: 'campaign_type', label: 'Type', type: 'text', width: 160, editable: true },
+    { id: 'keyword_or_group', label: 'Keyword / Group', type: 'text', width: 220, editable: true },
+    { id: 'match_type', label: 'Match Mix', type: 'text', width: 160, editable: true },
+    { id: 'bid_strategy', label: 'Bid Strategy', type: 'text', width: 200, editable: true },
+    {
+      id: 'avg_quality_score',
+      label: 'Avg. QS',
+      type: 'number',
+      width: 140,
+      editable: true,
+      align: 'right',
+      precision: 1,
+    },
+  ],
+  Radio: [
+    { id: 'network_or_platform', label: 'Network / Platform', type: 'text', width: 200, editable: true },
+    { id: 'station', label: 'Station', type: 'text', width: 160, editable: true },
+    { id: 'daypart', label: 'Daypart', type: 'text', width: 160, editable: true },
+    {
+      id: 'spot_length_sec',
+      label: 'Spot Length (sec)',
+      type: 'number',
+      width: 180,
+      editable: true,
+      align: 'right',
+    },
+    { id: 'spots', label: 'Spots', type: 'number', width: 140, editable: true, align: 'right' },
+    { id: 'format_genre', label: 'Format / Genre', type: 'text', width: 200, editable: true },
+    {
+      id: 'cpp_or_cpm',
+      label: 'CPP / CPM',
+      type: 'currency',
+      width: 160,
+      editable: true,
+      align: 'right',
+    },
+  ],
+  Streaming_Audio: [
+    { id: 'network_or_platform', label: 'Platform', type: 'text', width: 200, editable: true },
+    { id: 'station', label: 'Stream', type: 'text', width: 160, editable: true },
+    { id: 'daypart', label: 'Daypart', type: 'text', width: 160, editable: true },
+    {
+      id: 'spot_length_sec',
+      label: 'Spot Length (sec)',
+      type: 'number',
+      width: 180,
+      editable: true,
+      align: 'right',
+    },
+    { id: 'spots', label: 'Spots', type: 'number', width: 140, editable: true, align: 'right' },
+    { id: 'format_genre', label: 'Format / Genre', type: 'text', width: 200, editable: true },
+    {
+      id: 'cpp_or_cpm',
+      label: 'CPP / CPM',
+      type: 'currency',
+      width: 160,
+      editable: true,
+      align: 'right',
+    },
+  ],
+  Podcast: [
+    { id: 'publisher_show', label: 'Publisher / Show', type: 'text', width: 220, editable: true },
+    { id: 'episode_or_date', label: 'Episode / Date', type: 'text', width: 200, editable: true },
+    { id: 'ad_position', label: 'Ad Position', type: 'enum', width: 160, editable: true, enum: ['Pre', 'Mid', 'Post'] },
+    { id: 'read_type', label: 'Read Type', type: 'enum', width: 160, editable: true, enum: ['Talent', 'Announcer'] },
+    { id: 'insertion_type', label: 'Insertion', type: 'enum', width: 160, editable: true, enum: ['Baked-in', 'Dynamic'] },
+    { id: 'est_downloads', label: 'Est. Downloads', type: 'number', width: 180, editable: true, align: 'right' },
+  ],
+  Cinema: [
+    { id: 'circuit', label: 'Circuit', type: 'text', width: 160, editable: true },
+    { id: 'locations_count', label: 'Locations', type: 'number', width: 160, editable: true, align: 'right' },
+    { id: 'screens_count', label: 'Screens', type: 'number', width: 160, editable: true, align: 'right' },
+    { id: 'sessions_per_week', label: 'Sessions / Week', type: 'number', width: 180, editable: true, align: 'right' },
+    {
+      id: 'spot_length_sec',
+      label: 'Spot Length (sec)',
+      type: 'number',
+      width: 160,
+      editable: true,
+      align: 'right',
+    },
+    { id: 'package', label: 'Package', type: 'text', width: 160, editable: true },
+  ],
+  Print: [
+    { id: 'publication', label: 'Publication', type: 'text', width: 200, editable: true },
+    { id: 'section', label: 'Section', type: 'text', width: 160, editable: true },
+    { id: 'edition_date', label: 'Edition Date', type: 'date', width: 160, editable: true },
+    { id: 'ad_size', label: 'Ad Size', type: 'text', width: 160, editable: true },
+    { id: 'position', label: 'Position', type: 'text', width: 160, editable: true },
+    { id: 'color_mode', label: 'Color', type: 'enum', width: 140, editable: true, enum: ['B/W', '4C'] },
+  ],
+  Retail_Media: [
+    { id: 'retailer', label: 'Retailer', type: 'text', width: 180, editable: true },
+    { id: 'onsite_format', label: 'Onsite Format', type: 'text', width: 200, editable: true },
+    { id: 'offsite_format', label: 'Offsite Format', type: 'text', width: 200, editable: true },
+    { id: 'sku_count', label: 'SKU Count', type: 'number', width: 160, editable: true, align: 'right' },
+    { id: 'attribution_source', label: 'Attribution Source', type: 'text', width: 200, editable: true },
+    { id: 'roas_target', label: 'ROAS Target', type: 'number', width: 160, editable: true, align: 'right', precision: 2 },
+  ],
+  Influencer: [
+    { id: 'creator_handle', label: 'Creator', type: 'text', width: 200, editable: true },
+    { id: 'platform', label: 'Platform', type: 'text', width: 160, editable: true },
+    { id: 'deliverables_short', label: 'Deliverables', type: 'text', width: 200, editable: true },
+    { id: 'followers_k', label: 'Followers (k)', type: 'number', width: 180, editable: true, align: 'right', precision: 1 },
+    { id: 'usage_window_days', label: 'Usage Window (days)', type: 'number', width: 200, editable: true, align: 'right' },
+    { id: 'whitelisting', label: 'Whitelisting', type: 'boolean', width: 160, editable: true },
+  ],
+  Sponsorship: [
+    { id: 'property', label: 'Property', type: 'text', width: 200, editable: true },
+    { id: 'rights_summary', label: 'Rights Summary', type: 'text', width: 220, editable: true },
+    { id: 'key_dates', label: 'Key Dates', type: 'text', width: 180, editable: true },
+    { id: 'assets_count', label: 'Asset Count', type: 'number', width: 160, editable: true, align: 'right' },
+    { id: 'makegoods', label: 'Makegoods', type: 'boolean', width: 140, editable: true },
+  ],
+  Email: [
+    { id: 'type_email_or_dm', label: 'Channel', type: 'enum', width: 160, editable: true, enum: ['email', 'direct_mail'] },
+    { id: 'platform_or_broker', label: 'Platform / Broker', type: 'text', width: 200, editable: true },
+    { id: 'audience_size', label: 'Audience Size', type: 'number', width: 180, editable: true, align: 'right' },
+    { id: 'send_or_drop_date', label: 'Send / Drop Date', type: 'date', width: 180, editable: true },
+    { id: 'template_or_format', label: 'Template / Format', type: 'text', width: 200, editable: true },
+    { id: 'seed_or_broker', label: 'Seed / Broker', type: 'text', width: 200, editable: true },
+  ],
+  Direct_Mail: [
+    { id: 'type_email_or_dm', label: 'Channel', type: 'enum', width: 160, editable: true, enum: ['email', 'direct_mail'] },
+    { id: 'platform_or_broker', label: 'Platform / Broker', type: 'text', width: 200, editable: true },
+    { id: 'audience_size', label: 'Audience Size', type: 'number', width: 180, editable: true, align: 'right' },
+    { id: 'send_or_drop_date', label: 'Send / Drop Date', type: 'date', width: 180, editable: true },
+    { id: 'template_or_format', label: 'Template / Format', type: 'text', width: 200, editable: true },
+    { id: 'seed_or_broker', label: 'Seed / Broker', type: 'text', width: 200, editable: true },
+  ],
+  Gaming: [
+    { id: 'subtype', label: 'Subtype', type: 'enum', width: 160, editable: true, enum: ['Gaming', 'Native', 'In-App'] },
+    { id: 'platform_or_network', label: 'Platform / Network', type: 'text', width: 200, editable: true },
+    { id: 'title_or_publisher', label: 'Title / Publisher', type: 'text', width: 200, editable: true },
+    { id: 'ad_format', label: 'Ad Format', type: 'text', width: 180, editable: true },
+    { id: 'brand_safety', label: 'Brand Safety', type: 'text', width: 180, editable: true },
+  ],
+  Native: [
+    { id: 'subtype', label: 'Subtype', type: 'enum', width: 160, editable: true, enum: ['Gaming', 'Native', 'In-App'] },
+    { id: 'platform_or_network', label: 'Platform / Network', type: 'text', width: 200, editable: true },
+    { id: 'title_or_publisher', label: 'Title / Publisher', type: 'text', width: 200, editable: true },
+    { id: 'ad_format', label: 'Ad Format', type: 'text', width: 180, editable: true },
+    { id: 'brand_safety', label: 'Brand Safety', type: 'text', width: 180, editable: true },
+  ],
+  Affiliate: [
+    { id: 'network', label: 'Network', type: 'text', width: 200, editable: true },
+    { id: 'partner', label: 'Partner', type: 'text', width: 200, editable: true },
+    { id: 'commission_model', label: 'Commission', type: 'enum', width: 180, editable: true, enum: ['CPS', 'CPL', 'Flat'] },
+    {
+      id: 'cookie_window_days',
+      label: 'Cookie Window (days)',
+      type: 'number',
+      width: 200,
+      editable: true,
+      align: 'right',
+    },
+    { id: 'promo_codes_count', label: 'Promo Codes', type: 'number', width: 180, editable: true, align: 'right' },
+  ],
+  Experiential: [
+    { id: 'property', label: 'Property', type: 'text', width: 200, editable: true },
+    { id: 'rights_summary', label: 'Rights Summary', type: 'text', width: 220, editable: true },
+    { id: 'key_dates', label: 'Key Dates', type: 'text', width: 180, editable: true },
+    { id: 'assets_count', label: 'Asset Count', type: 'number', width: 160, editable: true, align: 'right' },
+    { id: 'makegoods', label: 'Makegoods', type: 'boolean', width: 140, editable: true },
+  ],
+};
+
+export const channelTableConfig: HierarchicalTableConfig = {
+  topLevelColumns: [
+    { id: 'channel', label: 'Channel', type: 'text', width: 200 },
+    { id: 'start_date', label: 'Start Date', type: 'date', width: 140 },
+    { id: 'end_date', label: 'End Date', type: 'date', width: 140 },
+    { id: 'total_planned_cost', label: 'Total Planned Cost', type: 'currency', width: 180, align: 'right' },
+    { id: 'budget_percent', label: 'Budget %', type: 'percent', width: 140, align: 'right', precision: 1 },
+    { id: 'actions', label: 'Actions', type: 'text', width: 240 },
+  ],
+  flightingCommonColumns: baseCommonColumns,
+  channelSpecificColumns: channelSpecificColumns,
+};
+
+export type { ColumnSpec, ColumnType, HierarchicalTableConfig };

--- a/src/data/seed.ts
+++ b/src/data/seed.ts
@@ -936,8 +936,16 @@ const deliveryActuals = lineItems.flatMap((item, index) =>
 export const plans = [
   planSchema.parse({
     id: 'plan-aurora-fy25',
-    meta: { name: 'Aurora Sparkling FY25 Launch', code: 'AURORA-FY25', version: 1 },
+    meta: {
+      name: 'Aurora Sparkling FY25 Launch',
+      client: 'Aurora Beverages',
+      code: 'AURORA-FY25',
+      version: 1,
+    },
     status: 'Draft',
+    start_date: '2025-09-23',
+    end_date: '2025-12-22',
+    week_start_day: 'Monday',
     goal: { budget: 1_200_000, reach: 6_200_000, frequency: 3.2 },
     campaigns,
     flights,

--- a/src/lib/blockPlan.ts
+++ b/src/lib/blockPlan.ts
@@ -1,0 +1,150 @@
+import { planSchema, type BlockPlan, type LineItem, type Plan, type WeekStartDay } from '@/lib/schemas';
+import { addDays, enumeratePlanWeeks, startOfWeek, toIsoDate } from '@/lib/date';
+import type { Flight } from '@/lib/schemas';
+
+function clonePlan(plan: Plan): Plan {
+  return planSchema.parse(JSON.parse(JSON.stringify(plan)));
+}
+
+function ensureBlockPlanContainer(lineItem: LineItem): BlockPlan {
+  if (!lineItem.block_plan) {
+    lineItem.block_plan = { version: 1, week_unit: 'plan-week', weeks: [] };
+  }
+  return lineItem.block_plan;
+}
+
+function buildActiveSetFromFlight(flight: Flight | undefined, plan: Plan): Set<string> {
+  const active = new Set<string>();
+  if (!flight) return active;
+  const weeks = enumeratePlanWeeks(plan.start_date, plan.end_date, plan.week_start_day);
+  const flightStart = new Date(flight.start_date);
+  const flightEnd = new Date(flight.end_date);
+  for (const week of weeks) {
+    const weekStart = week.start.getTime();
+    const weekEnd = week.end.getTime();
+    if (weekEnd < flightStart.getTime()) continue;
+    if (weekStart > flightEnd.getTime()) continue;
+    active.add(week.key);
+  }
+  return active;
+}
+
+function alignBlockPlanWeeks(
+  plan: Plan,
+  lineItem: LineItem,
+  flight: Flight | undefined,
+  preserveExisting: boolean,
+) {
+  const blockPlan = ensureBlockPlanContainer(lineItem);
+  const weeks = enumeratePlanWeeks(plan.start_date, plan.end_date, plan.week_start_day);
+  const existing = new Map(blockPlan.weeks.map((week) => [week.week_start, week.active]));
+  const fallback = buildActiveSetFromFlight(flight, plan);
+  const nextWeeks = weeks.map((week) => {
+    const preserved = existing.get(week.key);
+    const active = preserveExisting
+      ? preserved ?? fallback.has(week.key)
+      : fallback.has(week.key);
+    return { week_start: week.key, active };
+  });
+
+  if (!nextWeeks.some((week) => week.active) && fallback.size > 0) {
+    blockPlan.weeks = weeks.map((week) => ({ week_start: week.key, active: fallback.has(week.key) }));
+  } else {
+    blockPlan.weeks = nextWeeks;
+  }
+}
+
+function collectActiveWeekStarts(lineItem: LineItem, weekStart: WeekStartDay): Set<string> {
+  const active = new Set<string>();
+  if (!lineItem.block_plan) return active;
+  for (const week of lineItem.block_plan.weeks) {
+    if (!week.active) continue;
+    const start = startOfWeek(new Date(week.week_start), weekStart);
+    active.add(toIsoDate(start));
+  }
+  return active;
+}
+
+function updateFlightFromBlockPlan(lineItem: LineItem, flight: Flight | undefined) {
+  if (!flight || !lineItem.block_plan) return;
+  const activeWeeks = lineItem.block_plan.weeks.filter((week) => week.active);
+  if (activeWeeks.length === 0) {
+    return;
+  }
+  activeWeeks.sort((a, b) => a.week_start.localeCompare(b.week_start));
+  const first = activeWeeks[0];
+  const last = activeWeeks[activeWeeks.length - 1];
+  flight.start_date = first.week_start;
+  flight.end_date = toIsoDate(addDays(new Date(last.week_start), 6));
+}
+
+export function ensurePlanBlockPlans(plan: Plan): Plan {
+  const next = clonePlan(plan);
+  for (const lineItem of next.lineItems) {
+    const flight = next.flights.find((item) => item.flight_id === lineItem.flight_id);
+    alignBlockPlanWeeks(next, lineItem, flight, true);
+  }
+  return planSchema.parse(next);
+}
+
+export function syncBlockPlanToFlight(plan: Plan, lineItemId: string): Plan {
+  const next = clonePlan(plan);
+  const lineItem = next.lineItems.find((item) => item.line_item_id === lineItemId);
+  if (!lineItem) return plan;
+  const flight = next.flights.find((item) => item.flight_id === lineItem.flight_id);
+  alignBlockPlanWeeks(next, lineItem, flight, false);
+  updateFlightFromBlockPlan(lineItem, flight);
+  return updatePlanTimeline(next);
+}
+
+export function toggleBlockPlanWeek(plan: Plan, lineItemId: string, weekStart: string): Plan {
+  const next = clonePlan(plan);
+  const lineItem = next.lineItems.find((item) => item.line_item_id === lineItemId);
+  if (!lineItem) return plan;
+  const flight = next.flights.find((item) => item.flight_id === lineItem.flight_id);
+  alignBlockPlanWeeks(next, lineItem, flight, true);
+  const blockPlan = ensureBlockPlanContainer(lineItem);
+  const target = blockPlan.weeks.find((week) => week.week_start === weekStart);
+  if (!target) return plan;
+  const nextState = !target.active;
+  target.active = nextState;
+  if (!blockPlan.weeks.some((week) => week.active)) {
+    target.active = true;
+    return plan;
+  }
+  updateFlightFromBlockPlan(lineItem, flight);
+  return updatePlanTimeline(next);
+}
+
+export function changePlanWeekStart(plan: Plan, weekStart: WeekStartDay): Plan {
+  if (plan.week_start_day === weekStart) return plan;
+  const next = clonePlan(plan);
+  next.week_start_day = weekStart;
+  for (const lineItem of next.lineItems) {
+    const flight = next.flights.find((item) => item.flight_id === lineItem.flight_id);
+    const activeWeeks = collectActiveWeekStarts(lineItem, weekStart);
+    const weeks = enumeratePlanWeeks(next.start_date, next.end_date, weekStart);
+    ensureBlockPlanContainer(lineItem);
+    lineItem.block_plan!.weeks = weeks.map((week) => ({
+      week_start: week.key,
+      active: activeWeeks.size > 0 ? activeWeeks.has(week.key) : false,
+    }));
+    if (!lineItem.block_plan!.weeks.some((week) => week.active)) {
+      alignBlockPlanWeeks(next, lineItem, flight, false);
+    }
+    updateFlightFromBlockPlan(lineItem, flight);
+  }
+  return updatePlanTimeline(next);
+}
+
+export function updatePlanTimeline(plan: Plan): Plan {
+  const next = clonePlan(plan);
+  if (next.flights.length === 0) {
+    return planSchema.parse(next);
+  }
+  const startDates = next.flights.map((flight) => flight.start_date).sort();
+  const endDates = next.flights.map((flight) => flight.end_date).sort();
+  next.start_date = startDates[0];
+  next.end_date = endDates[endDates.length - 1];
+  return planSchema.parse(next);
+}

--- a/src/lib/channelExtensions.ts
+++ b/src/lib/channelExtensions.ts
@@ -1,0 +1,33 @@
+import type { Channel, LineItem } from './schemas';
+
+type ExtensionKey = Extract<keyof LineItem, `${string}_ext`>;
+
+export const extensionKeyByChannel: Partial<Record<Channel, ExtensionKey>> = {
+  OOH: 'ooh_ext',
+  TV: 'tv_ext',
+  BVOD_CTV: 'bvod_ext',
+  Digital_Display: 'digital_ext',
+  Digital_Video: 'digital_ext',
+  Social: 'social_ext',
+  Search: 'search_ext',
+  Radio: 'audio_ext',
+  Streaming_Audio: 'audio_ext',
+  Podcast: 'podcast_ext',
+  Cinema: 'cinema_ext',
+  Print: 'print_ext',
+  Retail_Media: 'retail_media_ext',
+  Influencer: 'influencer_ext',
+  Sponsorship: 'sponsorship_ext',
+  Email: 'email_dm_ext',
+  Direct_Mail: 'email_dm_ext',
+  Gaming: 'gaming_native_ext',
+  Native: 'gaming_native_ext',
+  Affiliate: 'affiliate_ext',
+  Experiential: 'sponsorship_ext',
+};
+
+export function getChannelExtension(lineItem: LineItem) {
+  const key = extensionKeyByChannel[lineItem.channel];
+  if (!key) return undefined;
+  return lineItem[key];
+}

--- a/src/lib/channelTable.ts
+++ b/src/lib/channelTable.ts
@@ -1,0 +1,1068 @@
+import { channelTableConfig } from '@/config/channelTableConfig';
+import {
+  planSchema,
+  channelEnum,
+  pricingModelEnum,
+  type Plan,
+  type Channel,
+  type LineItem,
+  type Flight,
+  type Vendor,
+  type Audience,
+  type PricingModel,
+} from '@/lib/schemas';
+import { percentFormatter } from '@/lib/formatters';
+import { syncBlockPlanToFlight } from '@/lib/blockPlan';
+
+type FieldPath = string;
+
+type FlightingValue = string | number | boolean | null | undefined;
+
+type FlightingRowContext = {
+  plan: Plan;
+  lineItem: LineItem;
+  flight?: Flight;
+  vendor?: Vendor;
+  audience?: Audience;
+};
+
+type FieldWriteResult = {
+  plan: Plan;
+  lineItem: LineItem;
+  flight?: Flight;
+  vendor?: Vendor;
+  audience?: Audience;
+};
+
+type FlightingFieldResolver = {
+  read: (context: FlightingRowContext) => FlightingValue;
+  write?: (context: FlightingRowContext, value: FlightingValue) => FieldWriteResult;
+  validate?: (value: FlightingValue, context: FlightingRowContext) => string | null;
+};
+
+type ChannelSummary = {
+  channel: Channel;
+  startDate: string | null;
+  endDate: string | null;
+  totalPlannedCost: number;
+  budgetPercent: number;
+  lineItemIds: string[];
+};
+
+type ValidationIssue = {
+  field: string;
+  message: string;
+};
+
+const extensionDefaultsByKey: Record<string, () => Record<string, unknown>> = {
+  ooh_ext: () => ({
+    ooh_asset_id: '',
+    owner: '',
+    format: '',
+    digital: false,
+    address: '',
+    suburb: '',
+    state: 'NSW',
+    postcode: '',
+    lat: 0,
+    long: 0,
+  }),
+  tv_ext: () => ({
+    network: '',
+    spot_length_sec: 30,
+    spot_count: 0,
+    buy_unit: 'spot',
+  }),
+  bvod_ext: () => ({
+    platform: '',
+    buy_type: 'audience',
+  }),
+  digital_ext: () => ({
+    inventory_type: 'display',
+  }),
+  social_ext: () => ({
+    platform: '',
+  }),
+  search_ext: () => ({
+    engine: 'Google',
+    campaign_type: 'Search',
+    ad_group: 'Default',
+  }),
+  audio_ext: () => ({
+    network_or_platform: '',
+    spot_len_sec: 30,
+    spots: 0,
+  }),
+  podcast_ext: () => ({
+    publisher: '',
+    show: '',
+  }),
+  cinema_ext: () => ({
+    circuit: '',
+    spot_len_sec: 30,
+  }),
+  print_ext: () => ({
+    publication: '',
+    edition_date: new Date().toISOString().slice(0, 10),
+  }),
+  retail_media_ext: () => ({
+    retailer: '',
+    onsite_format: '',
+  }),
+  influencer_ext: () => ({
+    creator_handle: '',
+    platform: '',
+  }),
+  sponsorship_ext: () => ({
+    property: '',
+  }),
+  email_dm_ext: () => ({
+    channel_type: 'email',
+    list_source: '',
+  }),
+  gaming_native_ext: () => ({
+    subtype: 'gaming',
+    title_or_publisher: '',
+  }),
+  affiliate_ext: () => ({
+    network: '',
+    partner_id: '',
+    commission_model: 'CPS',
+  }),
+};
+
+function clonePlan(plan: Plan): Plan {
+  return planSchema.parse(JSON.parse(JSON.stringify(plan)));
+}
+
+function mutatePlan(context: FlightingRowContext, mutate: (draft: FlightingRowContext) => void): FieldWriteResult {
+  const draft = clonePlan(context.plan);
+  const lineIndex = draft.lineItems.findIndex((item) => item.line_item_id === context.lineItem.line_item_id);
+  if (lineIndex === -1) {
+    throw new Error(`Line item ${context.lineItem.line_item_id} not found`);
+  }
+  const draftContext: FlightingRowContext = {
+    plan: draft,
+    lineItem: draft.lineItems[lineIndex],
+    flight: context.flight
+      ? draft.flights.find((item) => item.flight_id === context.flight?.flight_id)
+      : undefined,
+    vendor: context.vendor
+      ? draft.vendors.find((item) => item.vendor_id === context.vendor?.vendor_id)
+      : undefined,
+    audience: context.audience
+      ? draft.audiences.find((item) => item.audience_id === context.audience?.audience_id)
+      : undefined,
+  };
+
+  mutate(draftContext);
+
+  draft.lineItems[lineIndex] = draftContext.lineItem;
+  if (draftContext.flight) {
+    const flightIndex = draft.flights.findIndex((item) => item.flight_id === draftContext.flight?.flight_id);
+    if (flightIndex >= 0) draft.flights[flightIndex] = draftContext.flight;
+  }
+  if (draftContext.vendor) {
+    const vendorIndex = draft.vendors.findIndex((item) => item.vendor_id === draftContext.vendor?.vendor_id);
+    if (vendorIndex >= 0) draft.vendors[vendorIndex] = draftContext.vendor;
+  }
+  if (draftContext.audience) {
+    const audienceIndex = draft.audiences.findIndex((item) => item.audience_id === draftContext.audience?.audience_id);
+    if (audienceIndex >= 0) draft.audiences[audienceIndex] = draftContext.audience;
+  }
+
+  return draftContext;
+}
+
+function readByPath(context: FlightingRowContext, path: FieldPath): FlightingValue {
+  const segments = path.split('.');
+  let target: unknown = context;
+  for (const segment of segments) {
+    if (target == null || typeof target !== 'object') return undefined;
+    target = (target as Record<string, unknown>)[segment];
+  }
+  return target as FlightingValue;
+}
+
+function writeByPath(context: FlightingRowContext, path: FieldPath, value: FlightingValue): FieldWriteResult {
+  return mutatePlan(context, (draft) => {
+    const segments = path.split('.');
+    let target: Record<string, unknown> = draft as unknown as Record<string, unknown>;
+    for (let index = 0; index < segments.length - 1; index += 1) {
+      const segment = segments[index];
+      const next = target[segment];
+      if (next == null || typeof next !== 'object') {
+        const factory = extensionDefaultsByKey[segment];
+        target[segment] = factory ? factory() : {};
+      }
+      target = target[segment] as Record<string, unknown>;
+    }
+    target[segments.at(-1) ?? ''] = value as unknown;
+  });
+}
+
+function createPathResolver(path: FieldPath, options?: {
+  validate?: FlightingFieldResolver['validate'];
+  transformWrite?: (value: FlightingValue, context: FlightingRowContext) => FlightingValue;
+  transformRead?: (value: FlightingValue, context: FlightingRowContext) => FlightingValue;
+}): FlightingFieldResolver {
+  return {
+    read: (context) => {
+      const raw = readByPath(context, path);
+      return options?.transformRead ? options.transformRead(raw, context) : raw;
+    },
+    write: (context, value) => {
+      const nextValue = options?.transformWrite ? options.transformWrite(value, context) : value;
+      return writeByPath(context, path, nextValue);
+    },
+    validate: options?.validate,
+  };
+}
+
+function registerChannelResolver(channel: Channel, field: string, resolver: FlightingFieldResolver) {
+  if (!channelResolvers[channel]) {
+    channelResolvers[channel] = {};
+  }
+  channelResolvers[channel]![field] = resolver;
+}
+
+const commonResolvers: Record<string, FlightingFieldResolver> = {
+  vendor_platform: createPathResolver('vendor.name', {
+    validate: (value) => {
+      if (!value || String(value).trim().length === 0) {
+        return 'Vendor is required';
+      }
+      return null;
+    },
+  }),
+  start_date: {
+    read: (context) => context.flight?.start_date ?? null,
+    write: (context, value) => {
+      if (!value) throw new Error('Start date required');
+      return mutatePlan(context, (draft) => {
+        if (!draft.flight) {
+          throw new Error('Missing flight for update');
+        }
+        draft.flight = { ...draft.flight, start_date: String(value) };
+      });
+    },
+    validate: (value, context) => {
+      if (!value) return 'Start date is required';
+      const start = new Date(String(value));
+      if (Number.isNaN(start.getTime())) return 'Invalid start date';
+      if (context.flight?.end_date && start > new Date(context.flight.end_date)) {
+        return 'Start must be before end';
+      }
+      return null;
+    },
+  },
+  end_date: {
+    read: (context) => context.flight?.end_date ?? null,
+    write: (context, value) => {
+      if (!value) throw new Error('End date required');
+      return mutatePlan(context, (draft) => {
+        if (!draft.flight) {
+          throw new Error('Missing flight for update');
+        }
+        draft.flight = { ...draft.flight, end_date: String(value) };
+      });
+    },
+    validate: (value, context) => {
+      if (!value) return 'End date is required';
+      const end = new Date(String(value));
+      if (Number.isNaN(end.getTime())) return 'Invalid end date';
+      if (context.flight?.start_date && end < new Date(context.flight.start_date)) {
+        return 'End must be after start';
+      }
+      return null;
+    },
+  },
+  pricing_model: {
+    read: (context) => context.lineItem.pricing_model,
+    write: (context, value) => {
+      const next = pricingModelEnum.parse(value);
+      return mutatePlan(context, (draft) => {
+        draft.lineItem = { ...draft.lineItem, pricing_model: next };
+      });
+    },
+    validate: (value) => {
+      if (!value) return 'Pricing model is required';
+      if (!pricingModelEnum.options.includes(value as PricingModel)) {
+        return 'Invalid pricing model';
+      }
+      return null;
+    },
+  },
+  rate: createPathResolver('lineItem.rate_numeric', {
+    transformWrite: (value) => {
+      const numeric = Number(value ?? 0);
+      if (!Number.isFinite(numeric) || numeric < 0) return 0;
+      return numeric;
+    },
+    validate: (value, context) => {
+      if (value == null || value === '') {
+        return context.lineItem.pricing_model === 'Fixed' ? null : 'Rate required';
+      }
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric) || numeric < 0) {
+        return 'Rate must be non-negative';
+      }
+      return null;
+    },
+  }),
+  units_planned: createPathResolver('lineItem.units_planned', {
+    transformWrite: (value) => {
+      const numeric = Number(value ?? 0);
+      if (!Number.isFinite(numeric) || numeric < 0) return 0;
+      return numeric;
+    },
+    validate: (value) => {
+      if (value == null || value === '') return null;
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric) || numeric < 0) return 'Units must be non-negative';
+      return null;
+    },
+  }),
+  planned_cost: createPathResolver('lineItem.cost_planned', {
+    transformWrite: (value) => {
+      const numeric = Number(value ?? 0);
+      if (!Number.isFinite(numeric) || numeric < 0) return 0;
+      return numeric;
+    },
+    validate: (value) => {
+      if (value == null || value === '') return 'Planned cost required';
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric) || numeric < 0) return 'Planned cost must be non-negative';
+      return null;
+    },
+  }),
+  primary_kpi: createPathResolver('lineItem.goal_type'),
+  audience_label: createPathResolver('audience.definition'),
+};
+
+const channelResolvers: Partial<Record<Channel, Record<string, FlightingFieldResolver>>> = {};
+
+const channelPathResolvers: Partial<Record<Channel, Record<string, FieldPath>>> = {
+  OOH: {
+    owner: 'lineItem.ooh_ext.owner',
+    format: 'lineItem.ooh_ext.format',
+    sites: 'lineItem.units_planned',
+    weekly_imps: 'lineItem.ooh_ext.weekly_imps',
+  },
+  TV: {
+    network_region: 'lineItem.tv_ext.network',
+    program_or_daypart: 'lineItem.tv_ext.program',
+    spot_length_sec: 'lineItem.tv_ext.spot_length_sec',
+    spots: 'lineItem.tv_ext.spot_count',
+    buy_unit: 'lineItem.tv_ext.buy_unit',
+    target_demo: 'lineItem.tv_ext.target_demo',
+  },
+  BVOD_CTV: {
+    platform: 'lineItem.bvod_ext.platform',
+    buy_type: 'lineItem.bvod_ext.buy_type',
+    pod_position: 'lineItem.bvod_ext.pod_position',
+    viewability_standard: 'lineItem.bvod_ext.viewability_standard',
+  },
+  Digital_Display: {
+    exchange_or_deal: 'lineItem.digital_ext.deal_id',
+    inventory_type: 'lineItem.digital_ext.inventory_type',
+    creative_sizes: 'lineItem.digital_ext.creative_sizes',
+    targeting_short: 'lineItem.digital_ext.targeting_json',
+    brand_safety_tier: 'lineItem.digital_ext.brand_safety',
+  },
+  Digital_Video: {
+    exchange_or_deal: 'lineItem.digital_ext.deal_id',
+    inventory_type: 'lineItem.digital_ext.inventory_type',
+    pod_or_position: 'lineItem.digital_ext.pod_position',
+    brand_safety_tier: 'lineItem.digital_ext.brand_safety',
+  },
+  Social: {
+    platform: 'lineItem.social_ext.platform',
+    objective: 'lineItem.social_ext.objective',
+    format: 'lineItem.social_ext.format',
+    optimization_event: 'lineItem.social_ext.optimization_event',
+    attribution_window: 'lineItem.social_ext.attribution_window',
+    frequency_cap: 'lineItem.social_ext.frequency_cap',
+  },
+  Search: {
+    engine: 'lineItem.search_ext.engine',
+    campaign_type: 'lineItem.search_ext.campaign_type',
+    keyword_or_group: 'lineItem.search_ext.keyword',
+    match_type: 'lineItem.search_ext.match_type',
+    bid_strategy: 'lineItem.search_ext.bid_strategy',
+    avg_quality_score: 'lineItem.search_ext.avg_quality_score',
+  },
+  Radio: {
+    network_or_platform: 'lineItem.audio_ext.network_or_platform',
+    station: 'lineItem.audio_ext.station',
+    daypart: 'lineItem.audio_ext.daypart',
+    spot_length_sec: 'lineItem.audio_ext.spot_len_sec',
+    spots: 'lineItem.audio_ext.spots',
+    format_genre: 'lineItem.audio_ext.format_genre',
+    cpp_or_cpm: 'lineItem.audio_ext.cpp_or_cpm',
+  },
+  Streaming_Audio: {
+    network_or_platform: 'lineItem.audio_ext.network_or_platform',
+    station: 'lineItem.audio_ext.station',
+    daypart: 'lineItem.audio_ext.daypart',
+    spot_length_sec: 'lineItem.audio_ext.spot_len_sec',
+    spots: 'lineItem.audio_ext.spots',
+    format_genre: 'lineItem.audio_ext.format_genre',
+    cpp_or_cpm: 'lineItem.audio_ext.cpp_or_cpm',
+  },
+  Podcast: {
+    episode_or_date: 'lineItem.podcast_ext.episode',
+  },
+  Cinema: {
+    circuit: 'lineItem.cinema_ext.circuit',
+    locations_count: 'lineItem.cinema_ext.locations_count',
+    screens_count: 'lineItem.cinema_ext.screens_count',
+    sessions_per_week: 'lineItem.cinema_ext.sessions_per_week',
+    spot_length_sec: 'lineItem.cinema_ext.spot_len_sec',
+    package: 'lineItem.cinema_ext.package',
+  },
+  Print: {
+    publication: 'lineItem.print_ext.publication',
+    section: 'lineItem.print_ext.section',
+    edition_date: 'lineItem.print_ext.edition_date',
+    ad_size: 'lineItem.print_ext.ad_size',
+    position: 'lineItem.print_ext.position',
+    color_mode: 'lineItem.print_ext.color_mode',
+  },
+  Retail_Media: {
+    retailer: 'lineItem.retail_media_ext.retailer',
+    onsite_format: 'lineItem.retail_media_ext.onsite_format',
+    offsite_format: 'lineItem.retail_media_ext.offsite_format',
+    sku_count: 'lineItem.retail_media_ext.sku_count',
+    attribution_source: 'lineItem.retail_media_ext.attribution_source',
+    roas_target: 'lineItem.retail_media_ext.roas_target',
+  },
+  Influencer: {
+    creator_handle: 'lineItem.influencer_ext.creator_handle',
+    platform: 'lineItem.influencer_ext.platform',
+    deliverables_short: 'lineItem.influencer_ext.deliverables_short',
+    followers_k: 'lineItem.influencer_ext.followers_k',
+    usage_window_days: 'lineItem.influencer_ext.usage_window_days',
+    whitelisting: 'lineItem.influencer_ext.whitelisting',
+  },
+  Sponsorship: {
+    property: 'lineItem.sponsorship_ext.property',
+    rights_summary: 'lineItem.sponsorship_ext.rights_summary',
+    key_dates: 'lineItem.sponsorship_ext.key_dates',
+    assets_count: 'lineItem.sponsorship_ext.assets_count',
+    makegoods: 'lineItem.sponsorship_ext.makegoods',
+  },
+  Email: {
+    type_email_or_dm: 'lineItem.email_dm_ext.channel_type',
+    platform_or_broker: 'lineItem.email_dm_ext.list_source',
+    audience_size: 'lineItem.email_dm_ext.audience_size',
+    send_or_drop_date: 'lineItem.email_dm_ext.drop_date',
+    template_or_format: 'lineItem.email_dm_ext.template_id',
+    seed_or_broker: 'lineItem.email_dm_ext.list_broker',
+  },
+  Direct_Mail: {
+    type_email_or_dm: 'lineItem.email_dm_ext.channel_type',
+    platform_or_broker: 'lineItem.email_dm_ext.list_source',
+    audience_size: 'lineItem.email_dm_ext.audience_size',
+    send_or_drop_date: 'lineItem.email_dm_ext.drop_date',
+    template_or_format: 'lineItem.email_dm_ext.template_id',
+    seed_or_broker: 'lineItem.email_dm_ext.list_broker',
+  },
+  Gaming: {
+    subtype: 'lineItem.gaming_native_ext.subtype',
+    platform_or_network: 'lineItem.gaming_native_ext.platform_network',
+    title_or_publisher: 'lineItem.gaming_native_ext.title_or_publisher',
+    ad_format: 'lineItem.gaming_native_ext.ad_format',
+    brand_safety: 'lineItem.gaming_native_ext.brand_safety',
+  },
+  Native: {
+    subtype: 'lineItem.gaming_native_ext.subtype',
+    platform_or_network: 'lineItem.gaming_native_ext.platform_network',
+    title_or_publisher: 'lineItem.gaming_native_ext.title_or_publisher',
+    ad_format: 'lineItem.gaming_native_ext.ad_format',
+    brand_safety: 'lineItem.gaming_native_ext.brand_safety',
+  },
+  Affiliate: {
+    network: 'lineItem.affiliate_ext.network',
+    partner: 'lineItem.affiliate_ext.partner_id',
+    commission_model: 'lineItem.affiliate_ext.commission_model',
+    cookie_window_days: 'lineItem.affiliate_ext.cookie_window_days',
+    promo_codes_count: 'lineItem.affiliate_ext.promo_codes_json',
+  },
+  Experiential: {
+    property: 'lineItem.sponsorship_ext.property',
+    rights_summary: 'lineItem.sponsorship_ext.rights_summary',
+    key_dates: 'lineItem.sponsorship_ext.key_dates',
+    assets_count: 'lineItem.sponsorship_ext.assets_count',
+    makegoods: 'lineItem.sponsorship_ext.makegoods',
+  },
+};
+
+for (const [channel, mapping] of Object.entries(channelPathResolvers)) {
+  const castChannel = channel as Channel;
+  for (const [field, path] of Object.entries(mapping ?? {})) {
+    registerChannelResolver(castChannel, field, createPathResolver(path));
+  }
+}
+
+function percentFromValue(value: FlightingValue): number {
+  const numeric = Number(value ?? 0);
+  if (!Number.isFinite(numeric)) return 0;
+  if (numeric > 1 && numeric <= 100) return numeric / 100;
+  return numeric;
+}
+
+registerChannelResolver('OOH', 'digital', {
+  read: (context) => Boolean(readByPath(context, 'lineItem.ooh_ext.digital')),
+  write: (context, value) => writeByPath(context, 'lineItem.ooh_ext.digital', Boolean(value)),
+  validate: (value, context) => {
+    if (Boolean(value) && !context.lineItem.ooh_ext?.share_of_voice) {
+      return 'Add SOV when digital panels are selected';
+    }
+    return null;
+  },
+});
+
+registerChannelResolver('OOH', 'sov_or_loop', {
+  read: (context) => {
+    const sov = context.lineItem.ooh_ext?.share_of_voice;
+    const loop = context.lineItem.ooh_ext?.slot_length_sec;
+    const sovLabel = sov != null ? percentFormatter.format(sov, { maximumFractionDigits: 1 }) : '';
+    const loopLabel = loop != null ? `${loop}s` : '';
+    return [sovLabel, loopLabel].filter(Boolean).join(' / ');
+  },
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const raw = String(value ?? '');
+      const [sovPart, loopPart] = raw.split('/').map((part) => part.trim());
+      const sovNumeric = Number(sovPart?.replace(/[^0-9.]/g, ''));
+      const loopNumeric = Number(loopPart?.replace(/[^0-9.]/g, ''));
+      const share = Number.isFinite(sovNumeric) ? (sovNumeric > 1 ? sovNumeric / 100 : sovNumeric) : undefined;
+      const loop = Number.isFinite(loopNumeric) ? loopNumeric : undefined;
+      const ext = extensionDefaultsByKey.ooh_ext();
+      draft.lineItem.ooh_ext = {
+        ...(draft.lineItem.ooh_ext ?? ext),
+        share_of_voice: share,
+        slot_length_sec: loop,
+      } as typeof draft.lineItem.ooh_ext;
+    }),
+});
+
+registerChannelResolver('OOH', 'facing_orientation', {
+  read: (context) => {
+    const facing = context.lineItem.ooh_ext?.facing;
+    const orientation = context.lineItem.ooh_ext?.orientation_deg;
+    if (!facing && orientation == null) return '';
+    return [facing, orientation != null ? `${orientation}°` : null].filter(Boolean).join(' ');
+  },
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const raw = String(value ?? '');
+      const [facing, orientation] = raw.split(' ').map((part) => part.trim());
+      const orientationValue = Number(orientation?.replace(/[^0-9.]/g, ''));
+      const defaultExt = extensionDefaultsByKey.ooh_ext();
+      const baseExt: NonNullable<typeof draft.lineItem.ooh_ext> =
+        draft.lineItem.ooh_ext ?? defaultExt;
+      draft.lineItem.ooh_ext = {
+        ...baseExt,
+        facing: (facing || baseExt.facing) ?? undefined,
+        orientation_deg: Number.isFinite(orientationValue)
+          ? orientationValue
+          : baseExt.orientation_deg,
+      } as typeof draft.lineItem.ooh_ext;
+    }),
+});
+
+registerChannelResolver('OOH', 'location', {
+  read: (context) => {
+    const ext = context.lineItem.ooh_ext;
+    if (!ext) return '';
+    return [ext.address, ext.suburb, ext.state].filter(Boolean).join(', ');
+  },
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const parts = String(value ?? '')
+        .split(',')
+        .map((part) => part.trim());
+      const [address, suburb, state] = parts;
+      const defaultExt = extensionDefaultsByKey.ooh_ext();
+      const ext: NonNullable<typeof draft.lineItem.ooh_ext> = draft.lineItem.ooh_ext ?? defaultExt;
+      const resolvedState = state && state.length > 0 ? state : ext.state ?? 'NSW';
+      draft.lineItem.ooh_ext = {
+        ...ext,
+        address: address ?? ext.address ?? '',
+        suburb: suburb ?? ext.suburb ?? '',
+        state: resolvedState,
+      };
+    }),
+});
+
+registerChannelResolver('OOH', 'production_install_fees', {
+  read: (context) => (context.lineItem.ooh_ext?.production_cost ?? 0) + (context.lineItem.ooh_ext?.install_cost ?? 0),
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const total = Number(value ?? 0);
+      const defaultExt = extensionDefaultsByKey.ooh_ext();
+      const ext: NonNullable<typeof draft.lineItem.ooh_ext> = draft.lineItem.ooh_ext ?? defaultExt;
+      draft.lineItem.ooh_ext = {
+        ...ext,
+        production_cost: Number.isFinite(total) ? Math.max(0, total / 2) : ext.production_cost ?? 0,
+        install_cost: Number.isFinite(total) ? Math.max(0, total / 2) : ext.install_cost ?? 0,
+      };
+    }),
+});
+
+registerChannelResolver('BVOD_CTV', 'device_mix_ctv_pct', {
+  read: (context) => context.lineItem.bvod_ext?.device_mix_json?.find((item) => item.device === 'CTV')?.share ?? null,
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const share = Math.min(1, Math.max(0, percentFromValue(value)));
+      const ext = draft.lineItem.bvod_ext ?? (extensionDefaultsByKey.bvod_ext() as typeof draft.lineItem.bvod_ext);
+      const remaining = (ext.device_mix_json ?? []).filter((item) => item.device !== 'CTV');
+      draft.lineItem.bvod_ext = {
+        ...ext,
+        device_mix_json: [...remaining, { device: 'CTV', share }],
+      };
+    }),
+});
+
+registerChannelResolver('BVOD_CTV', 'ad_duration_sec', {
+  read: (context) => context.lineItem.bvod_ext?.ad_pod_len ?? null,
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.bvod_ext ?? (extensionDefaultsByKey.bvod_ext() as typeof draft.lineItem.bvod_ext);
+      draft.lineItem.bvod_ext = {
+        ...ext,
+        ad_pod_len: Math.max(0, Math.floor(Number(value ?? 0))) || 0,
+      };
+    }),
+});
+
+registerChannelResolver('BVOD_CTV', 'vcr_goal_pct', {
+  read: (context) => {
+    const raw = context.lineItem.bvod_ext?.completion_goal;
+    if (!raw) return null;
+    const parsed = Number(String(raw).replace(/[^0-9.]/g, ''));
+    if (!Number.isFinite(parsed)) return null;
+    return parsed / 100;
+  },
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.bvod_ext ?? (extensionDefaultsByKey.bvod_ext() as typeof draft.lineItem.bvod_ext);
+      const percent = Math.min(1, Math.max(0, percentFromValue(value)));
+      draft.lineItem.bvod_ext = {
+        ...ext,
+        completion_goal: `${Math.round(percent * 100)}%`,
+      };
+    }),
+});
+
+registerChannelResolver('Digital_Display', 'creative_sizes', {
+  read: (context) => (context.lineItem.digital_ext?.creative_sizes ?? []).join(', '),
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.digital_ext ?? (extensionDefaultsByKey.digital_ext() as typeof draft.lineItem.digital_ext);
+      const sizes = String(value ?? '')
+        .split(',')
+        .map((part) => part.trim())
+        .filter(Boolean);
+      draft.lineItem.digital_ext = { ...ext, creative_sizes: sizes };
+    }),
+});
+
+registerChannelResolver('Digital_Display', 'targeting_short', {
+  read: (context) => Object.keys(context.lineItem.digital_ext?.targeting_json ?? {}).join(', '),
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.digital_ext ?? (extensionDefaultsByKey.digital_ext() as typeof draft.lineItem.digital_ext);
+      const keys = String(value ?? '')
+        .split(',')
+        .map((part) => part.trim())
+        .filter(Boolean);
+      const targeting = Object.fromEntries(keys.map((key) => [key, true]));
+      draft.lineItem.digital_ext = { ...ext, targeting_json: targeting };
+    }),
+});
+
+registerChannelResolver('Digital_Display', 'viewability_goal_pct', {
+  read: (context) => context.lineItem.digital_ext?.viewability_goal ?? null,
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.digital_ext ?? (extensionDefaultsByKey.digital_ext() as typeof draft.lineItem.digital_ext);
+      draft.lineItem.digital_ext = {
+        ...ext,
+        viewability_goal: Math.min(1, Math.max(0, percentFromValue(value))),
+      };
+    }),
+});
+
+registerChannelResolver('Digital_Video', 'ad_duration_sec', {
+  read: (context) => context.lineItem.digital_ext?.video_duration_sec ?? null,
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.digital_ext ?? (extensionDefaultsByKey.digital_ext() as typeof draft.lineItem.digital_ext);
+      draft.lineItem.digital_ext = {
+        ...ext,
+        video_duration_sec: Math.max(0, Math.floor(Number(value ?? 0))) || 0,
+      };
+    }),
+});
+
+registerChannelResolver('Digital_Video', 'vcr_goal_pct', {
+  read: (context) => context.lineItem.digital_ext?.viewability_goal ?? null,
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.digital_ext ?? (extensionDefaultsByKey.digital_ext() as typeof draft.lineItem.digital_ext);
+      draft.lineItem.digital_ext = {
+        ...ext,
+        viewability_goal: Math.min(1, Math.max(0, percentFromValue(value))),
+      };
+    }),
+});
+
+registerChannelResolver('Search', 'keyword_or_group', {
+  read: (context) => context.lineItem.search_ext?.keyword ?? context.lineItem.search_ext?.ad_group ?? '',
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.search_ext ?? (extensionDefaultsByKey.search_ext() as typeof draft.lineItem.search_ext);
+      draft.lineItem.search_ext = { ...ext, keyword: String(value ?? '') };
+    }),
+});
+
+registerChannelResolver('Search', 'avg_quality_score', {
+  read: (context) => context.lineItem.search_ext?.avg_quality_score ?? null,
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.search_ext ?? (extensionDefaultsByKey.search_ext() as typeof draft.lineItem.search_ext);
+      draft.lineItem.search_ext = {
+        ...ext,
+        avg_quality_score: Math.max(0, Number(value ?? 0)) || 0,
+      };
+    }),
+});
+
+registerChannelResolver('Radio', 'cpp_or_cpm', {
+  read: (context) => context.lineItem.audio_ext?.cpp_or_cpm ?? null,
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.audio_ext ?? (extensionDefaultsByKey.audio_ext() as typeof draft.lineItem.audio_ext);
+      draft.lineItem.audio_ext = { ...ext, cpp_or_cpm: Math.max(0, Number(value ?? 0)) || 0 };
+    }),
+});
+
+registerChannelResolver('Streaming_Audio', 'cpp_or_cpm', {
+  read: (context) => context.lineItem.audio_ext?.cpp_or_cpm ?? null,
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.audio_ext ?? (extensionDefaultsByKey.audio_ext() as typeof draft.lineItem.audio_ext);
+      draft.lineItem.audio_ext = { ...ext, cpp_or_cpm: Math.max(0, Number(value ?? 0)) || 0 };
+    }),
+});
+
+registerChannelResolver('Podcast', 'publisher_show', {
+  read: (context) =>
+    [context.lineItem.podcast_ext?.publisher, context.lineItem.podcast_ext?.show]
+      .filter(Boolean)
+      .join(' – '),
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.podcast_ext ?? (extensionDefaultsByKey.podcast_ext() as typeof draft.lineItem.podcast_ext);
+      const [publisher, show] = String(value ?? '')
+        .split('–')
+        .map((part) => part.trim());
+      draft.lineItem.podcast_ext = {
+        ...ext,
+        publisher: publisher ?? ext.publisher,
+        show: show ?? ext.show,
+      };
+    }),
+});
+
+registerChannelResolver('Podcast', 'ad_position', {
+  read: (context) => context.lineItem.podcast_ext?.ad_position ?? '',
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.podcast_ext ?? (extensionDefaultsByKey.podcast_ext() as typeof draft.lineItem.podcast_ext);
+      draft.lineItem.podcast_ext = { ...ext, ad_position: String(value ?? '') as typeof ext.ad_position };
+    }),
+});
+
+registerChannelResolver('Podcast', 'read_type', {
+  read: (context) => context.lineItem.podcast_ext?.read_type ?? '',
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.podcast_ext ?? (extensionDefaultsByKey.podcast_ext() as typeof draft.lineItem.podcast_ext);
+      draft.lineItem.podcast_ext = { ...ext, read_type: String(value ?? '') as typeof ext.read_type };
+    }),
+});
+
+registerChannelResolver('Podcast', 'insertion_type', {
+  read: (context) => context.lineItem.podcast_ext?.insertion_type ?? '',
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.podcast_ext ?? (extensionDefaultsByKey.podcast_ext() as typeof draft.lineItem.podcast_ext);
+      draft.lineItem.podcast_ext = { ...ext, insertion_type: String(value ?? '') as typeof ext.insertion_type };
+    }),
+});
+
+registerChannelResolver('Podcast', 'est_downloads', {
+  read: (context) => context.lineItem.podcast_ext?.est_downloads ?? null,
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.podcast_ext ?? (extensionDefaultsByKey.podcast_ext() as typeof draft.lineItem.podcast_ext);
+      draft.lineItem.podcast_ext = { ...ext, est_downloads: Math.max(0, Math.floor(Number(value ?? 0))) };
+    }),
+});
+
+registerChannelResolver('Retail_Media', 'sku_count', {
+  read: (context) => context.lineItem.retail_media_ext?.sku_count ?? null,
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.retail_media_ext ?? (extensionDefaultsByKey.retail_media_ext() as typeof draft.lineItem.retail_media_ext);
+      draft.lineItem.retail_media_ext = { ...ext, sku_count: Math.max(0, Math.floor(Number(value ?? 0))) };
+    }),
+});
+
+registerChannelResolver('Retail_Media', 'roas_target', {
+  read: (context) => context.lineItem.retail_media_ext?.roas_target ?? null,
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.retail_media_ext ?? (extensionDefaultsByKey.retail_media_ext() as typeof draft.lineItem.retail_media_ext);
+      draft.lineItem.retail_media_ext = { ...ext, roas_target: Math.max(0, Number(value ?? 0)) || 0 };
+    }),
+});
+
+registerChannelResolver('Influencer', 'followers_k', {
+  read: (context) => context.lineItem.influencer_ext?.followers_k ?? null,
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.influencer_ext ?? (extensionDefaultsByKey.influencer_ext() as typeof draft.lineItem.influencer_ext);
+      draft.lineItem.influencer_ext = { ...ext, followers_k: Math.max(0, Number(value ?? 0)) };
+    }),
+});
+
+registerChannelResolver('Influencer', 'usage_window_days', {
+  read: (context) => context.lineItem.influencer_ext?.usage_window_days ?? null,
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.influencer_ext ?? (extensionDefaultsByKey.influencer_ext() as typeof draft.lineItem.influencer_ext);
+      draft.lineItem.influencer_ext = {
+        ...ext,
+        usage_window_days: Math.max(0, Math.floor(Number(value ?? 0))) || 0,
+      };
+    }),
+});
+
+registerChannelResolver('Influencer', 'whitelisting', {
+  read: (context) => Boolean(context.lineItem.influencer_ext?.whitelisting),
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.influencer_ext ?? (extensionDefaultsByKey.influencer_ext() as typeof draft.lineItem.influencer_ext);
+      draft.lineItem.influencer_ext = { ...ext, whitelisting: Boolean(value) };
+    }),
+});
+
+registerChannelResolver('Sponsorship', 'assets_count', {
+  read: (context) => context.lineItem.sponsorship_ext?.assets_count ?? null,
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.sponsorship_ext ?? (extensionDefaultsByKey.sponsorship_ext() as typeof draft.lineItem.sponsorship_ext);
+      draft.lineItem.sponsorship_ext = {
+        ...ext,
+        assets_count: Math.max(0, Math.floor(Number(value ?? 0))) || 0,
+      };
+    }),
+});
+
+registerChannelResolver('Sponsorship', 'makegoods', {
+  read: (context) => Boolean(context.lineItem.sponsorship_ext?.makegoods),
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.sponsorship_ext ?? (extensionDefaultsByKey.sponsorship_ext() as typeof draft.lineItem.sponsorship_ext);
+      draft.lineItem.sponsorship_ext = { ...ext, makegoods: Boolean(value) };
+    }),
+});
+
+registerChannelResolver('Experiential', 'assets_count', {
+  read: (context) => context.lineItem.sponsorship_ext?.assets_count ?? null,
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.sponsorship_ext ?? (extensionDefaultsByKey.sponsorship_ext() as typeof draft.lineItem.sponsorship_ext);
+      draft.lineItem.sponsorship_ext = {
+        ...ext,
+        assets_count: Math.max(0, Math.floor(Number(value ?? 0))) || 0,
+      };
+    }),
+});
+
+registerChannelResolver('Experiential', 'makegoods', {
+  read: (context) => Boolean(context.lineItem.sponsorship_ext?.makegoods),
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.sponsorship_ext ?? (extensionDefaultsByKey.sponsorship_ext() as typeof draft.lineItem.sponsorship_ext);
+      draft.lineItem.sponsorship_ext = { ...ext, makegoods: Boolean(value) };
+    }),
+});
+
+registerChannelResolver('Email', 'audience_size', {
+  read: (context) => context.lineItem.email_dm_ext?.audience_size ?? null,
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.email_dm_ext ?? (extensionDefaultsByKey.email_dm_ext() as typeof draft.lineItem.email_dm_ext);
+      draft.lineItem.email_dm_ext = { ...ext, audience_size: Math.max(0, Math.floor(Number(value ?? 0))) || 0 };
+    }),
+});
+
+registerChannelResolver('Direct_Mail', 'audience_size', {
+  read: (context) => context.lineItem.email_dm_ext?.audience_size ?? null,
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.email_dm_ext ?? (extensionDefaultsByKey.email_dm_ext() as typeof draft.lineItem.email_dm_ext);
+      draft.lineItem.email_dm_ext = { ...ext, audience_size: Math.max(0, Math.floor(Number(value ?? 0))) || 0 };
+    }),
+});
+
+registerChannelResolver('Affiliate', 'promo_codes_count', {
+  read: (context) => context.lineItem.affiliate_ext?.promo_codes_json?.length ?? 0,
+  write: (context, value) =>
+    mutatePlan(context, (draft) => {
+      const ext = draft.lineItem.affiliate_ext ?? (extensionDefaultsByKey.affiliate_ext() as typeof draft.lineItem.affiliate_ext);
+      const count = Math.max(0, Math.floor(Number(value ?? 0))) || 0;
+      draft.lineItem.affiliate_ext = {
+        ...ext,
+        promo_codes_json: new Array(count).fill('').map((_, index) => ext.promo_codes_json?.[index] ?? ''),
+      };
+    }),
+});
+
+export function getFieldResolver(channel: Channel, field: string): FlightingFieldResolver | undefined {
+  return channelResolvers[channel]?.[field] ?? commonResolvers[field];
+}
+
+export function listFieldsForChannel(channel: Channel): string[] {
+  const config = channelTableConfig.channelSpecificColumns[channel] ?? [];
+  return [...channelTableConfig.flightingCommonColumns.map((column) => column.id), ...config.map((column) => column.id)];
+}
+
+export function buildFlightingContexts(plan: Plan, channel: Channel): FlightingRowContext[] {
+  const flightById = new Map(plan.flights.map((flight) => [flight.flight_id, flight]));
+  const vendorById = new Map(plan.vendors.map((vendor) => [vendor.vendor_id, vendor]));
+  const audienceById = new Map(plan.audiences.map((audience) => [audience.audience_id, audience]));
+
+  return plan.lineItems
+    .filter((lineItem) => lineItem.channel === channel)
+    .map((lineItem) => ({
+      plan,
+      lineItem,
+      flight: flightById.get(lineItem.flight_id),
+      vendor: vendorById.get(lineItem.vendor_id),
+      audience: audienceById.get(lineItem.audience_id),
+    }))
+    .sort((a, b) => {
+      const aDate = a.flight ? new Date(a.flight.start_date).getTime() : Number.POSITIVE_INFINITY;
+      const bDate = b.flight ? new Date(b.flight.start_date).getTime() : Number.POSITIVE_INFINITY;
+      return aDate - bDate;
+    });
+}
+
+export function computeChannelSummaries(plan: Plan): ChannelSummary[] {
+  const budget = plan.goal?.budget ?? 0;
+  const summaries: ChannelSummary[] = [];
+
+  for (const channel of channelEnum.options) {
+    const contexts = buildFlightingContexts(plan, channel);
+    if (contexts.length === 0) continue;
+
+    let start: string | null = null;
+    let end: string | null = null;
+    let totalCost = 0;
+
+    for (const context of contexts) {
+      if (context.flight) {
+        if (!start || context.flight.start_date < start) {
+          start = context.flight.start_date;
+        }
+        if (!end || context.flight.end_date > end) {
+          end = context.flight.end_date;
+        }
+      }
+      totalCost += context.lineItem.cost_planned;
+    }
+
+    summaries.push({
+      channel,
+      startDate: start,
+      endDate: end,
+      totalPlannedCost: totalCost,
+      budgetPercent: budget > 0 ? totalCost / budget : 0,
+      lineItemIds: contexts.map((context) => context.lineItem.line_item_id),
+    });
+  }
+
+  return summaries.sort((a, b) => a.channel.localeCompare(b.channel));
+}
+
+export function validateField(
+  channel: Channel,
+  context: FlightingRowContext,
+  field: string,
+  value: FlightingValue,
+): ValidationIssue | null {
+  const resolver = getFieldResolver(channel, field);
+  if (!resolver?.validate) return null;
+  const message = resolver.validate(value, context);
+  if (!message) return null;
+  return { field, message };
+}
+
+export function setFieldValue(
+  channel: Channel,
+  context: FlightingRowContext,
+  field: string,
+  value: FlightingValue,
+): FieldWriteResult {
+  const resolver = getFieldResolver(channel, field);
+  if (!resolver?.write) {
+    throw new Error(`Field ${field} is read-only or not configured`);
+  }
+  const result = resolver.write(context, value);
+  if (field === 'start_date' || field === 'end_date') {
+    const syncedPlan = syncBlockPlanToFlight(result.plan, result.lineItem.line_item_id);
+    const refreshedLineItem = syncedPlan.lineItems.find(
+      (item) => item.line_item_id === result.lineItem.line_item_id,
+    );
+    const refreshedFlight = refreshedLineItem
+      ? syncedPlan.flights.find((item) => item.flight_id === refreshedLineItem.flight_id)
+      : undefined;
+    const refreshedVendor = result.vendor
+      ? syncedPlan.vendors.find((item) => item.vendor_id === result.vendor?.vendor_id)
+      : result.vendor;
+    const refreshedAudience = result.audience
+      ? syncedPlan.audiences.find((item) => item.audience_id === result.audience?.audience_id)
+      : result.audience;
+
+    return {
+      plan: syncedPlan,
+      lineItem: refreshedLineItem ?? result.lineItem,
+      flight: refreshedFlight ?? result.flight,
+      vendor: refreshedVendor ?? result.vendor,
+      audience: refreshedAudience ?? result.audience,
+    };
+  }
+  return result;
+}
+
+export function getFieldValue(channel: Channel, context: FlightingRowContext, field: string): FlightingValue {
+  const resolver = getFieldResolver(channel, field);
+  if (!resolver) return undefined;
+  return resolver.read(context);
+}
+
+export type {
+  ChannelSummary,
+  FieldWriteResult,
+  FlightingFieldResolver,
+  FlightingRowContext,
+  FlightingValue,
+  ValidationIssue,
+};

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,9 +1,77 @@
+const LOCALE = 'en-AU';
+
+export type WeekStartDay = 'Sunday' | 'Monday';
+
 export function formatDate(value: string | Date) {
   const date = typeof value === 'string' ? new Date(value) : value;
-  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(date);
+  return new Intl.DateTimeFormat(LOCALE, { dateStyle: 'medium' }).format(date);
+}
+
+export function formatDateTime(value: string | Date) {
+  const date = typeof value === 'string' ? new Date(value) : value;
+  return new Intl.DateTimeFormat(LOCALE, { dateStyle: 'medium', timeStyle: 'short' }).format(date);
 }
 
 export function formatDateRange(start: string, end: string) {
-  const formatter = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' });
+  const formatter = new Intl.DateTimeFormat(LOCALE, { month: 'short', day: 'numeric' });
   return `${formatter.format(new Date(start))} – ${formatter.format(new Date(end))}`;
+}
+
+export function startOfWeek(input: Date, weekStart: WeekStartDay) {
+  const date = new Date(input);
+  date.setHours(0, 0, 0, 0);
+  const currentDay = date.getDay();
+  const weekStartIndex = weekStart === 'Monday' ? 1 : 0;
+  const diff = (currentDay - weekStartIndex + 7) % 7;
+  date.setDate(date.getDate() - diff);
+  return date;
+}
+
+export function endOfWeek(input: Date, weekStart: WeekStartDay) {
+  const start = startOfWeek(input, weekStart);
+  start.setDate(start.getDate() + 6);
+  return start;
+}
+
+export function startOfWeekSunday(input: Date) {
+  return startOfWeek(input, 'Sunday');
+}
+
+export function endOfWeekSaturday(input: Date) {
+  return endOfWeek(input, 'Sunday');
+}
+
+export function addDays(input: Date, amount: number) {
+  const date = new Date(input);
+  date.setDate(date.getDate() + amount);
+  return date;
+}
+
+export function toIsoDate(input: Date) {
+  const copy = new Date(input);
+  copy.setHours(0, 0, 0, 0);
+  const offsetMinutes = copy.getTimezoneOffset();
+  const adjusted = new Date(copy.getTime() - offsetMinutes * 60 * 1000);
+  return adjusted.toISOString().slice(0, 10);
+}
+
+export function enumerateWeeksRange(start: Date, end: Date, weekStart: WeekStartDay) {
+  const weeks: { start: Date; end: Date; key: string }[] = [];
+  let cursor = startOfWeek(start, weekStart);
+  const limit = startOfWeek(end, weekStart);
+  while (cursor.getTime() <= limit.getTime()) {
+    const weekStartDate = new Date(cursor);
+    const weekEndDate = endOfWeek(weekStartDate, weekStart);
+    weeks.push({ start: weekStartDate, end: weekEndDate, key: toIsoDate(weekStartDate) });
+    cursor = addDays(cursor, 7);
+  }
+  return weeks;
+}
+
+export function enumerateWeeks(start: Date, end: Date) {
+  return enumerateWeeksRange(start, end, 'Sunday');
+}
+
+export function enumeratePlanWeeks(start: string, end: string, weekStart: WeekStartDay) {
+  return enumerateWeeksRange(new Date(start), new Date(end), weekStart);
 }

--- a/src/lib/db/schemas.ts
+++ b/src/lib/db/schemas.ts
@@ -12,6 +12,7 @@ import {
   planStatusSchema as appPlanStatusSchema,
   trackingSchema as appTrackingSchema,
   vendorSchema as appVendorSchema,
+  weekStartEnum,
 } from '@/lib/schemas';
 
 const isoDate = z.string().refine((value) => !Number.isNaN(Date.parse(value)), {
@@ -85,6 +86,9 @@ export const planSchema = z.object({
   updatedBy: z.string(),
   status: appPlanStatusSchema.default('Draft'),
   meta: appPlanMetaSchema.default({ name: '', code: '', version: 1 }),
+  startDate: isoDate.optional(),
+  endDate: isoDate.optional(),
+  weekStartDay: weekStartEnum.default('Monday'),
   goal: z
     .object({
       budget: z.number().nonnegative(),

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -1,14 +1,16 @@
-export const currencyFormatter = new Intl.NumberFormat(undefined, {
+const LOCALE = 'en-AU';
+
+export const currencyFormatter = new Intl.NumberFormat(LOCALE, {
   style: 'currency',
-  currency: 'USD',
+  currency: 'AUD',
   maximumFractionDigits: 0,
 });
 
-export const percentFormatter = new Intl.NumberFormat(undefined, {
+export const percentFormatter = new Intl.NumberFormat(LOCALE, {
   style: 'percent',
   maximumFractionDigits: 1,
 });
 
-export const numberFormatter = new Intl.NumberFormat(undefined, {
+export const numberFormatter = new Intl.NumberFormat(LOCALE, {
   maximumFractionDigits: 0,
 });

--- a/src/lib/planBuilders.ts
+++ b/src/lib/planBuilders.ts
@@ -1,0 +1,428 @@
+import {
+  campaignSchema,
+  audienceSchema,
+  vendorSchema,
+  creativeSchema,
+  flightSchema,
+  lineItemSchema,
+  trackingSchema,
+  planSchema,
+  type Plan,
+  type Channel,
+  type LineItem,
+} from '@/lib/schemas';
+import { createId } from '@/lib/id';
+import { addDays, startOfWeekSunday, toIsoDate } from '@/lib/date';
+import { syncBlockPlanToFlight, updatePlanTimeline } from '@/lib/blockPlan';
+
+const channelCreativeFormat: Partial<Record<Channel, string>> = {
+  TV: 'Video',
+  BVOD_CTV: 'Connected TV',
+  Digital_Display: 'Display',
+  Digital_Video: 'Video',
+  Social: 'Social',
+  Search: 'Search',
+  Radio: 'Audio',
+  Streaming_Audio: 'Audio',
+  Podcast: 'Podcast',
+  Cinema: 'Cinema',
+  Print: 'Print',
+  Retail_Media: 'Retail',
+  Influencer: 'Influencer',
+  Sponsorship: 'Sponsorship',
+  Email: 'Email',
+  Direct_Mail: 'Direct Mail',
+  Gaming: 'Gaming',
+  Native: 'Native',
+  Affiliate: 'Affiliate',
+  Experiential: 'Experiential',
+  OOH: 'OOH',
+};
+
+function defaultCampaign(plan: Plan) {
+  if (plan.campaigns.length > 0) {
+    return plan.campaigns[0];
+  }
+
+  return campaignSchema.parse({
+    campaign_id: createId('cmp'),
+    brand: plan.meta.client,
+    market: 'Australia',
+    objective: 'Define campaign objective',
+    primary_kpi: 'Reach',
+    fiscal_period: 'FY25',
+  });
+}
+
+function defaultAudience() {
+  return audienceSchema.parse({
+    audience_id: createId('aud'),
+    definition: 'Audience pending definition',
+    segments_json: [],
+  });
+}
+
+function defaultVendor() {
+  return vendorSchema.parse({
+    vendor_id: createId('vnd'),
+    name: 'Pending vendor',
+  });
+}
+
+function defaultCreative(channel: Channel) {
+  return creativeSchema.parse({
+    creative_id: createId('crv'),
+    ad_name: `${channel.replace(/_/g, ' ')} placeholder`,
+    asset_uri: 'https://example.com/assets/placeholder',
+    format: channelCreativeFormat[channel] ?? 'Standard',
+  });
+}
+
+function defaultLineItemExtension(channel: Channel) {
+  switch (channel) {
+    case 'OOH':
+      return {
+        ooh_ext: {
+          ooh_asset_id: createId('ooh'),
+          owner: 'Pending owner',
+          format: 'Large format digital',
+          digital: true,
+          address: '1 Example Way',
+          suburb: 'Sydney',
+          state: 'NSW',
+          postcode: '2000',
+          lat: -33.8688,
+          long: 151.2093,
+        },
+      } as const;
+    case 'TV':
+      return {
+        tv_ext: {
+          network: 'TBD Network',
+          spot_length_sec: 30,
+          spot_count: 10,
+          buy_unit: 'spot',
+        },
+      } as const;
+    case 'BVOD_CTV':
+      return {
+        bvod_ext: {
+          platform: '9Now',
+        },
+      } as const;
+    case 'Digital_Display':
+    case 'Digital_Video':
+      return {
+        digital_ext: {
+          inventory_type: 'display',
+        },
+      } as const;
+    case 'Social':
+      return {
+        social_ext: {
+          platform: 'Meta',
+          objective: 'Awareness',
+        },
+      } as const;
+    case 'Search':
+      return {
+        search_ext: {
+          engine: 'Google',
+          campaign_type: 'Search',
+          ad_group: 'New Ad Group',
+        },
+      } as const;
+    case 'Radio':
+    case 'Streaming_Audio':
+      return {
+        audio_ext: {
+          network_or_platform: 'Network TBD',
+          spot_len_sec: 30,
+          spots: 10,
+        },
+      } as const;
+    case 'Podcast':
+      return {
+        podcast_ext: {
+          publisher: 'Podcast Network',
+          show: 'Flagship Show',
+        },
+      } as const;
+    case 'Cinema':
+      return {
+        cinema_ext: {
+          circuit: 'Hoyts',
+          spot_len_sec: 30,
+        },
+      } as const;
+    case 'Print':
+      return {
+        print_ext: {
+          publication: 'Trade Publication',
+          edition_date: toIsoDate(new Date()),
+        },
+      } as const;
+    case 'Retail_Media':
+      return {
+        retail_media_ext: {
+          retailer: 'Cartology',
+        },
+      } as const;
+    case 'Influencer':
+      return {
+        influencer_ext: {
+          creator_handle: '@creator',
+          platform: 'Instagram',
+        },
+      } as const;
+    case 'Sponsorship':
+    case 'Experiential':
+      return {
+        sponsorship_ext: {
+          property: 'Sponsorship Property',
+        },
+      } as const;
+    case 'Email':
+      return {
+        email_dm_ext: {
+          channel_type: 'email',
+          list_source: 'First-party CRM',
+        },
+      } as const;
+    case 'Direct_Mail':
+      return {
+        email_dm_ext: {
+          channel_type: 'direct_mail',
+          list_source: 'Mailhouse partner',
+        },
+      } as const;
+    case 'Gaming':
+      return {
+        gaming_native_ext: {
+          subtype: 'gaming',
+          title_or_publisher: 'Gaming Partner',
+        },
+      } as const;
+    case 'Native':
+      return {
+        gaming_native_ext: {
+          subtype: 'native',
+          title_or_publisher: 'Native Partner',
+        },
+      } as const;
+    case 'Affiliate':
+      return {
+        affiliate_ext: {
+          network: 'Affiliate Network',
+          partner_id: createId('partner'),
+          commission_model: 'CPS',
+        },
+      } as const;
+    default:
+      return {} as const;
+  }
+}
+
+export function addChannelDraft(plan: Plan, channel: Channel): Plan {
+  const campaign = defaultCampaign(plan);
+  const audience = defaultAudience();
+  const vendor = defaultVendor();
+  const creative = defaultCreative(channel);
+
+  const now = new Date();
+  const start = startOfWeekSunday(now);
+  const end = addDays(start, 27);
+
+  const flight = flightSchema.parse({
+    flight_id: createId('flt'),
+    campaign_id: campaign.campaign_id,
+    start_date: toIsoDate(start),
+    end_date: toIsoDate(end),
+    budget_total: 0,
+    buy_type: 'Guaranteed',
+    buying_currency: 'AUD',
+    fx_rate: 1,
+  });
+
+  const lineItem = lineItemSchema.parse({
+    line_item_id: createId('li'),
+    flight_id: flight.flight_id,
+    audience_id: audience.audience_id,
+    vendor_id: vendor.vendor_id,
+    creative_id: creative.creative_id,
+    channel,
+    goal_type: 'Impressions',
+    pricing_model: 'CPM',
+    rate_numeric: 10,
+    rate_unit: 'CPM',
+    units_planned: 0,
+    cost_planned: 0,
+    pacing: 'Even',
+    ...defaultLineItemExtension(channel),
+  });
+
+  const tracking = trackingSchema.parse({
+    line_item_id: lineItem.line_item_id,
+  });
+
+  const campaigns = plan.campaigns.length > 0 ? [...plan.campaigns] : [...plan.campaigns, campaign];
+
+  return planSchema.parse({
+    ...plan,
+    campaigns,
+    flights: [...plan.flights, flight],
+    audiences: [...plan.audiences, audience],
+    vendors: [...plan.vendors, vendor],
+    creatives: [...plan.creatives, creative],
+    lineItems: [...plan.lineItems, lineItem],
+    tracking: [...plan.tracking, tracking],
+  });
+}
+
+function ensureEntity<T extends { [key: string]: unknown }>(
+  collection: T[],
+  entity: T,
+  key: keyof T,
+): { items: T[]; id: T[typeof key] } {
+  const existing = collection.find((item) => item[key] === entity[key]);
+  if (existing) {
+    return { items: collection, id: existing[key] };
+  }
+  return { items: [...collection, entity], id: entity[key] };
+}
+
+function findFirstLineItem(plan: Plan, channel: Channel): LineItem | undefined {
+  return plan.lineItems.find((item) => item.channel === channel);
+}
+
+export function addFlighting(plan: Plan, channel: Channel): Plan {
+  const baseLineItem = findFirstLineItem(plan, channel);
+  const campaign = plan.campaigns[0] ?? defaultCampaign(plan);
+  const audienceEntity = baseLineItem
+    ? plan.audiences.find((audience) => audience.audience_id === baseLineItem.audience_id) ?? defaultAudience()
+    : defaultAudience();
+  const vendorEntity = baseLineItem
+    ? plan.vendors.find((vendor) => vendor.vendor_id === baseLineItem.vendor_id) ?? defaultVendor()
+    : defaultVendor();
+  const creativeEntity = baseLineItem
+    ? plan.creatives.find((creative) => creative.creative_id === baseLineItem.creative_id) ?? defaultCreative(channel)
+    : defaultCreative(channel);
+
+  const now = new Date();
+  const start = startOfWeekSunday(now);
+  const end = addDays(start, 6);
+
+  const flight = flightSchema.parse({
+    flight_id: createId('flt'),
+    campaign_id: campaign.campaign_id,
+    start_date: toIsoDate(start),
+    end_date: toIsoDate(end),
+    budget_total: baseLineItem?.cost_planned ?? 0,
+    buy_type: baseLineItem?.pricing_model ?? 'Guaranteed',
+    buying_currency: 'AUD',
+    fx_rate: 1,
+  });
+
+  const extension = baseLineItem
+    ? (Object.fromEntries(
+        Object.entries(baseLineItem).filter(([key]) => key.endsWith('_ext')),
+      ) as Record<string, unknown>)
+    : defaultLineItemExtension(channel);
+
+  const lineItem = lineItemSchema.parse({
+    line_item_id: createId('li'),
+    flight_id: flight.flight_id,
+    audience_id: audienceEntity.audience_id,
+    vendor_id: vendorEntity.vendor_id,
+    creative_id: creativeEntity.creative_id,
+    channel,
+    goal_type: baseLineItem?.goal_type ?? 'Reach',
+    pricing_model: baseLineItem?.pricing_model ?? 'CPM',
+    rate_numeric: baseLineItem?.rate_numeric ?? 0,
+    rate_unit: baseLineItem?.rate_unit ?? 'CPM',
+    units_planned: baseLineItem?.units_planned ?? 0,
+    cost_planned: baseLineItem?.cost_planned ?? 0,
+    pacing: baseLineItem?.pacing ?? 'Even',
+    ...(extension as object),
+  });
+
+  const tracking = trackingSchema.parse({ line_item_id: lineItem.line_item_id });
+
+  const campaigns = plan.campaigns.length > 0 ? plan.campaigns : [campaign];
+  const { items: audiences } = ensureEntity(plan.audiences, audienceEntity, 'audience_id');
+  const { items: vendors } = ensureEntity(plan.vendors, vendorEntity, 'vendor_id');
+  const { items: creatives } = ensureEntity(plan.creatives, creativeEntity, 'creative_id');
+
+  const drafted = planSchema.parse({
+    ...plan,
+    campaigns,
+    flights: [...plan.flights, flight],
+    audiences,
+    vendors,
+    creatives,
+    lineItems: [...plan.lineItems, lineItem],
+    tracking: [...plan.tracking, tracking],
+  });
+
+  const withTimeline = updatePlanTimeline(drafted);
+  return syncBlockPlanToFlight(withTimeline, lineItem.line_item_id);
+}
+
+export function duplicateFlighting(plan: Plan, lineItemId: string): Plan {
+  const source = plan.lineItems.find((item) => item.line_item_id === lineItemId);
+  if (!source) {
+    return plan;
+  }
+  const flight = plan.flights.find((item) => item.flight_id === source.flight_id);
+  const newFlight = flightSchema.parse({
+    ...(flight ?? {
+      flight_id: createId('flt'),
+      campaign_id: plan.campaigns[0]?.campaign_id ?? defaultCampaign(plan).campaign_id,
+      start_date: toIsoDate(new Date()),
+      end_date: toIsoDate(addDays(new Date(), 6)),
+      budget_total: source.cost_planned,
+      buy_type: source.pricing_model,
+      buying_currency: 'AUD',
+      fx_rate: 1,
+    }),
+    flight_id: createId('flt'),
+  });
+
+  const duplicated = lineItemSchema.parse({
+    ...source,
+    flight_id: newFlight.flight_id,
+    line_item_id: createId('li'),
+  });
+
+  const tracking = trackingSchema.parse({ line_item_id: duplicated.line_item_id });
+
+  const drafted = planSchema.parse({
+    ...plan,
+    flights: [...plan.flights, newFlight],
+    lineItems: [...plan.lineItems, duplicated],
+    tracking: [...plan.tracking, tracking],
+  });
+
+  const withTimeline = updatePlanTimeline(drafted);
+  return syncBlockPlanToFlight(withTimeline, duplicated.line_item_id);
+}
+
+export function removeFlighting(plan: Plan, lineItemId: string): Plan {
+  const lineItem = plan.lineItems.find((item) => item.line_item_id === lineItemId);
+  if (!lineItem) return plan;
+  const remainingLineItems = plan.lineItems.filter((item) => item.line_item_id !== lineItemId);
+  const remainingTracking = plan.tracking.filter((item) => item.line_item_id !== lineItemId);
+  const otherUsage = remainingLineItems.some((item) => item.flight_id === lineItem.flight_id);
+  const remainingFlights = otherUsage
+    ? plan.flights
+    : plan.flights.filter((flight) => flight.flight_id !== lineItem.flight_id);
+
+  const updated = planSchema.parse({
+    ...plan,
+    flights: remainingFlights,
+    lineItems: remainingLineItems,
+    tracking: remainingTracking,
+  });
+
+  return updatePlanTimeline(updated);
+}

--- a/src/pages/BlockPlanPage.tsx
+++ b/src/pages/BlockPlanPage.tsx
@@ -1,0 +1,250 @@
+import { Fragment, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import clsx from 'clsx';
+import { usePlan, useMutatePlan } from '@/api/plans';
+import { Button } from '@/ui/Button';
+import { Select } from '@/ui/Select';
+import { Card } from '@/ui/Card';
+import { formatDate, formatDateRange, enumeratePlanWeeks } from '@/lib/date';
+import type { Plan, Channel, LineItem, WeekStartDay } from '@/lib/schemas';
+import {
+  changePlanWeekStart,
+  ensurePlanBlockPlans,
+  toggleBlockPlanWeek,
+} from '@/lib/blockPlan';
+import { currencyFormatter } from '@/lib/formatters';
+
+function groupLineItems(plan: Plan) {
+  const flightsById = new Map(plan.flights.map((flight) => [flight.flight_id, flight]));
+  const vendorsById = new Map(plan.vendors.map((vendor) => [vendor.vendor_id, vendor]));
+  const creativesById = new Map(plan.creatives.map((creative) => [creative.creative_id, creative]));
+
+  const groups = new Map<Channel, { channel: Channel; items: Array<{ lineItem: LineItem }> }>();
+  for (const lineItem of plan.lineItems) {
+    if (!groups.has(lineItem.channel)) {
+      groups.set(lineItem.channel, { channel: lineItem.channel, items: [] });
+    }
+    groups.get(lineItem.channel)?.items.push({ lineItem });
+  }
+
+  const sorted = Array.from(groups.values()).sort((a, b) => a.channel.localeCompare(b.channel));
+
+  return sorted.map((group) => ({
+    channel: group.channel,
+    label: group.channel.replace(/_/g, ' '),
+    rows: group.items
+      .map(({ lineItem }) => {
+        const flight = flightsById.get(lineItem.flight_id);
+        const vendor = vendorsById.get(lineItem.vendor_id);
+        const creative = creativesById.get(lineItem.creative_id);
+        const title = creative?.ad_name ?? vendor?.name ?? lineItem.line_item_id;
+        const sublabel = vendor?.name ?? creative?.ad_name ?? 'Flighting';
+        const blockPlanWeeks = lineItem.block_plan?.weeks ?? [];
+        const cost = currencyFormatter.format(lineItem.cost_planned);
+
+        return {
+          id: lineItem.line_item_id,
+          title,
+          sublabel,
+          flightRange: flight ? formatDateRange(flight.start_date, flight.end_date) : 'Unset',
+          cost,
+          lineItem,
+          weeks: blockPlanWeeks,
+        };
+      })
+      .sort((a, b) => a.flightRange.localeCompare(b.flightRange)),
+  }));
+}
+
+export function BlockPlanPage() {
+  const params = useParams();
+  const navigate = useNavigate();
+  const { data: plan, isLoading } = usePlan(params.id);
+  const mutatePlan = useMutatePlan();
+  const [workingPlan, setWorkingPlan] = useState<Plan | null>(null);
+
+  useEffect(() => {
+    if (!plan) return;
+    setWorkingPlan(ensurePlanBlockPlans(plan));
+  }, [plan]);
+
+  const weeks = useMemo(() => {
+    if (!workingPlan) return [];
+    return enumeratePlanWeeks(workingPlan.start_date, workingPlan.end_date, workingPlan.week_start_day);
+  }, [workingPlan]);
+
+  const groups = useMemo(() => {
+    if (!workingPlan) return [];
+    return groupLineItems(workingPlan);
+  }, [workingPlan]);
+
+  if (isLoading) {
+    return (
+      <main className="container mx-auto max-w-7xl px-4 py-6 lg:py-10">
+        <p className="text-sm text-slate-500" role="status">
+          Loading block plan…
+        </p>
+      </main>
+    );
+  }
+
+  if (!workingPlan) {
+    return (
+      <main className="container mx-auto max-w-5xl px-4 py-10">
+        <Card className="space-y-4 p-8 text-center">
+          <p className="text-base font-semibold text-slate-900">Plan not found</p>
+          <p className="text-sm text-slate-600">The requested plan could not be loaded.</p>
+          <Button onClick={() => navigate(-1)}>Back to plans</Button>
+        </Card>
+      </main>
+    );
+  }
+
+  const handleToggle = (lineItemId: string, weekKey: string) => {
+    const next = toggleBlockPlanWeek(workingPlan, lineItemId, weekKey);
+    setWorkingPlan(next);
+    mutatePlan.mutate(next);
+  };
+
+  const handleWeekStartChange = (value: string) => {
+    const next = changePlanWeekStart(workingPlan, value as WeekStartDay);
+    setWorkingPlan(next);
+    mutatePlan.mutate(next);
+  };
+
+  return (
+    <main className="container mx-auto max-w-7xl px-4 py-6 lg:py-10">
+      <div className="space-y-6">
+        <header className="flex flex-col gap-4 rounded-xl border border-slate-200 bg-white p-6 shadow-sm lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-indigo-600">Block plan</p>
+            <h1 className="text-2xl font-semibold text-slate-900 lg:text-3xl">{workingPlan.meta.name}</h1>
+            <p className="mt-1 text-sm text-slate-600">
+              {formatDateRange(workingPlan.start_date, workingPlan.end_date)}
+            </p>
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+            <label className="flex items-center gap-2 text-sm font-medium text-slate-700">
+              Week start
+              <Select
+                aria-label="Select week start"
+                value={workingPlan.week_start_day}
+                onChange={(event) => handleWeekStartChange(event.currentTarget.value)}
+              >
+                <option value="Monday">Monday</option>
+                <option value="Sunday">Sunday</option>
+              </Select>
+            </label>
+            <Button variant="secondary" onClick={() => navigate(`/plan/${workingPlan.id}`)}>
+              Back to plan
+            </Button>
+          </div>
+        </header>
+
+        <section aria-labelledby="block-plan-legend" className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 id="block-plan-legend" className="text-base font-semibold text-slate-900">
+                Weekly coverage
+              </h2>
+              <p className="text-sm text-slate-600">
+                Toggle weeks to mark when each flighting is in market. Filled squares indicate active weeks.
+              </p>
+            </div>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="min-w-full table-fixed border-collapse">
+              <thead className="bg-slate-100 text-xs uppercase tracking-wide text-slate-600">
+                <tr>
+                  <th
+                    className="sticky left-0 z-10 bg-slate-100 px-4 py-3 text-left"
+                    style={{ minWidth: '240px', width: '240px' }}
+                  >
+                    Flighting
+                  </th>
+                  <th
+                    className="sticky left-[240px] z-10 bg-slate-100 px-4 py-3 text-left"
+                    style={{ minWidth: '140px', width: '140px' }}
+                  >
+                    Cost
+                  </th>
+                  {weeks.map((week) => (
+                    <th key={week.key} className="px-3 py-3 text-center">
+                      <span className="block text-xs font-medium text-slate-700">
+                        {formatDate(week.start)}
+                      </span>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {groups.length === 0 ? (
+                  <tr>
+                    <td colSpan={weeks.length + 2} className="px-4 py-6 text-center text-sm text-slate-500">
+                      No flightings scheduled yet. Add line items in the main plan view to populate the block plan.
+                    </td>
+                  </tr>
+                ) : null}
+                {groups.map((group) => (
+                  <Fragment key={group.channel}>
+                    <tr className="border-t border-slate-200">
+                      <td
+                        colSpan={weeks.length + 2}
+                        className="bg-slate-50 px-4 py-2 text-sm font-semibold text-slate-700"
+                      >
+                        {group.label}
+                      </td>
+                    </tr>
+                    {group.rows.map((row) => (
+                      <tr key={row.id} className="border-t border-slate-200">
+                        <th
+                          scope="row"
+                          className="sticky left-0 z-[1] bg-white px-4 py-3 text-left text-sm font-medium text-slate-900"
+                          style={{ minWidth: '240px', width: '240px' }}
+                        >
+                          <div className="flex flex-col">
+                            <span>{row.title}</span>
+                            <span className="text-xs font-normal text-slate-500">{row.sublabel}</span>
+                            <span className="text-xs font-normal text-slate-500">{row.flightRange}</span>
+                          </div>
+                        </th>
+                        <td
+                          className="sticky left-[240px] z-[1] bg-white px-4 py-3 text-sm text-slate-700"
+                          style={{ minWidth: '140px', width: '140px' }}
+                        >
+                          {row.cost}
+                        </td>
+                        {weeks.map((week) => {
+                          const active = row.weeks.some((entry) => entry.week_start === week.key && entry.active);
+                          return (
+                            <td key={`${row.id}-${week.key}`} className="px-3 py-2 text-center">
+                              <button
+                                type="button"
+                                aria-pressed={active}
+                                className={clsx(
+                                  'mx-auto flex h-10 w-10 items-center justify-center rounded-md border text-lg transition focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2',
+                                  active
+                                    ? 'border-indigo-600 bg-indigo-600 font-semibold text-white shadow-sm'
+                                    : 'border-slate-300 bg-white text-slate-500 hover:border-indigo-400 hover:text-indigo-600',
+                                )}
+                                onClick={() => handleToggle(row.id, week.key)}
+                              >
+                                <span className="sr-only">Toggle week starting {formatDate(week.start)}</span>
+                                <span aria-hidden>{active ? '■' : '□'}</span>
+                              </button>
+                            </td>
+                          );
+                        })}
+                      </tr>
+                    ))}
+                  </Fragment>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,7 +1,8 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { usePlans, useCreatePlan, useDuplicatePlan } from '@/api/plans';
 import { Button } from '@/ui/Button';
-import { PlanList } from '@/components/PlanList';
+import { PlanList, type PlanListView } from '@/components/PlanList';
 import { useUser } from '@/auth/useUser';
 
 export function DashboardPage() {
@@ -10,6 +11,7 @@ export function DashboardPage() {
   const createPlan = useCreatePlan();
   const duplicatePlan = useDuplicatePlan();
   const { user } = useUser();
+  const [viewMode, setViewMode] = useState<PlanListView>('grid');
 
   const handleCreate = async () => {
     const plan = await createPlan.mutateAsync();
@@ -30,18 +32,37 @@ export function DashboardPage() {
               Manage media plans, versions, and approvals from one place.
             </p>
           </div>
-          <Button
-            onClick={handleCreate}
-            disabled={createPlan.isPending}
-            className="self-start sm:self-auto"
-          >
-            New Plan
-          </Button>
+          <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
+            <div className="inline-flex rounded-md border border-slate-200 bg-white p-1 text-xs font-medium text-slate-600 shadow-sm">
+              <button
+                type="button"
+                onClick={() => setViewMode('grid')}
+                className={`rounded px-3 py-1 transition ${viewMode === 'grid' ? 'bg-indigo-100 text-indigo-700' : 'hover:bg-slate-100'}`}
+              >
+                Card view
+              </button>
+              <button
+                type="button"
+                onClick={() => setViewMode('list')}
+                className={`rounded px-3 py-1 transition ${viewMode === 'list' ? 'bg-indigo-100 text-indigo-700' : 'hover:bg-slate-100'}`}
+              >
+                List view
+              </button>
+            </div>
+            <Button
+              onClick={handleCreate}
+              disabled={createPlan.isPending}
+              className="self-start sm:self-auto"
+            >
+              New Plan
+            </Button>
+          </div>
         </header>
         {isLoading ? <p className="text-sm text-slate-500">Loading plans...</p> : null}
         {!isLoading ? (
           <PlanList
             plans={plans}
+            viewMode={viewMode}
             onOpen={(id) => navigate(`/plan/${id}`)}
             onReview={(id) => navigate(`/plan/${id}/review`)}
             onDuplicate={handleDuplicate}

--- a/src/pages/PlanDetailPage.tsx
+++ b/src/pages/PlanDetailPage.tsx
@@ -3,7 +3,6 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { usePlan, useApprovePlan, useRejectPlan, useRevertPlan } from '@/api/plans';
 import { GoalKPIBar } from '@/components/GoalKPIBar';
 import { ChannelTable } from '@/components/ChannelTable';
-import { SummarySidebar } from '@/components/SummarySidebar';
 import { PacingWarnings } from '@/components/PacingWarnings';
 import { AuditDrawer } from '@/components/AuditDrawer';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
@@ -59,13 +58,10 @@ export function PlanDetailPage() {
         </Button>
       </div>
       <GoalKPIBar plan={plan} />
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[2fr,1fr]">
-        <div className="space-y-4">
-          <ChannelTable plan={plan} readOnly />
-          <PacingWarnings plan={plan} />
-          <AuditDrawer events={plan.audit} />
-        </div>
-        <SummarySidebar plan={plan} />
+      <div className="space-y-4">
+        <ChannelTable plan={plan} readOnly />
+        <PacingWarnings plan={plan} />
+        <AuditDrawer events={plan.audit} />
       </div>
       {canApprove(user) ? (
         <div className="flex flex-wrap gap-2">

--- a/src/store/firebaseAdapter.ts
+++ b/src/store/firebaseAdapter.ts
@@ -99,8 +99,17 @@ function deriveTimeframe(plan: PlanRecord | Plan) {
   const startDates = flights.map((flight) => new Date(flight.start_date).getTime());
   const endDates = flights.map((flight) => new Date(flight.end_date).getTime());
   const fallback = new Date().toISOString();
-  const start = startDates.length ? new Date(Math.min(...startDates)).toISOString() : fallback;
-  const end = endDates.length ? new Date(Math.max(...endDates)).toISOString() : fallback;
+  const startOverride =
+    'start_date' in plan
+      ? plan.start_date
+      : 'startDate' in plan
+        ? plan.startDate
+        : undefined;
+  const endOverride =
+    'end_date' in plan ? plan.end_date : 'endDate' in plan ? plan.endDate : undefined;
+  const start =
+    startOverride ?? (startDates.length ? new Date(Math.min(...startDates)).toISOString() : fallback);
+  const end = endOverride ?? (endDates.length ? new Date(Math.max(...endDates)).toISOString() : fallback);
   return { start, end };
 }
 
@@ -109,6 +118,9 @@ function recordToPlan(record: PlanRecord): Plan {
     id: record.id,
     meta: record.meta,
     status: record.status ?? stateToStatus[record.state],
+    start_date: record.startDate ?? record.timeframe.start.slice(0, 10),
+    end_date: record.endDate ?? record.timeframe.end.slice(0, 10),
+    week_start_day: record.weekStartDay ?? 'Monday',
     goal: record.goal,
     campaigns: record.campaigns,
     flights: record.flights,
@@ -152,6 +164,9 @@ function planToRecord(plan: Plan, scope: ScopedContext, previous?: PlanRecord): 
     audit: plan.audit,
     owner: plan.owner ?? previous?.owner ?? scope.user.id,
     approver: plan.approver ?? previous?.approver,
+    startDate: plan.start_date,
+    endDate: plan.end_date,
+    weekStartDay: plan.week_start_day,
     campaigns: plan.campaigns,
     flights: plan.flights,
     audiences: plan.audiences,

--- a/src/tests/ChannelTable.test.tsx
+++ b/src/tests/ChannelTable.test.tsx
@@ -1,0 +1,125 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent, within, cleanup } from '@testing-library/react';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { ChannelTable } from '@/components/ChannelTable';
+import { plans } from '@/data/seed';
+import type { Channel, Plan } from '@/lib/schemas';
+
+const plan = plans[0];
+const mutate = vi.fn();
+
+function buildSingleChannelPlan(channel: Channel): Plan {
+  const lineItems = plan.lineItems.filter((item) => item.channel === channel);
+  const lineItemIds = new Set(lineItems.map((item) => item.line_item_id));
+  const flightIds = new Set(lineItems.map((item) => item.flight_id));
+  const audienceIds = new Set(lineItems.map((item) => item.audience_id));
+  const vendorIds = new Set(lineItems.map((item) => item.vendor_id));
+  const creativeIds = new Set(lineItems.map((item) => item.creative_id));
+
+  return {
+    ...plan,
+    lineItems,
+    flights: plan.flights.filter((flight) => flightIds.has(flight.flight_id)),
+    audiences: plan.audiences.filter((audience) => audienceIds.has(audience.audience_id)),
+    vendors: plan.vendors.filter((vendor) => vendorIds.has(vendor.vendor_id)),
+    creatives: plan.creatives.filter((creative) => creativeIds.has(creative.creative_id)),
+    tracking: plan.tracking.filter((tracking) => lineItemIds.has(tracking.line_item_id)),
+    deliveryActuals: plan.deliveryActuals.filter((actual) => lineItemIds.has(actual.line_item_id)),
+  } satisfies Plan;
+}
+
+vi.mock('@/api/plans', async () => {
+  const actual = await vi.importActual<typeof import('@/api/plans')>('@/api/plans');
+  return {
+    ...actual,
+    useMutatePlan: () => ({ mutate }),
+  };
+});
+
+vi.mock('@/lib/planBuilders', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/planBuilders')>('@/lib/planBuilders');
+  const addFn = vi.fn((currentPlan: Plan, channel: Channel) => {
+    const template =
+      currentPlan.lineItems.find((item) => item.channel === channel) ?? currentPlan.lineItems[0];
+    const clone = { ...template, line_item_id: `${template.line_item_id}-copy` };
+    return {
+      ...currentPlan,
+      lineItems: [...currentPlan.lineItems, clone],
+    } satisfies Plan;
+  });
+  const removeFn = vi.fn((currentPlan: Plan, lineItemId: string) => ({
+    ...currentPlan,
+    lineItems: currentPlan.lineItems.filter((item) => item.line_item_id !== lineItemId),
+  }) satisfies Plan);
+  return {
+    ...actual,
+    addFlighting: addFn,
+    removeFlighting: removeFn,
+  };
+});
+
+describe('ChannelTable component', () => {
+  beforeEach(() => {
+    mutate.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders summary rows for each channel with budget percent', () => {
+    render(<ChannelTable plan={plan} readOnly />);
+    const summaryTable = screen.getAllByRole('table')[0];
+    for (const channel of new Set(plan.lineItems.map((item) => item.channel))) {
+      const label = channel.replace(/_/g, ' ');
+      expect(within(summaryTable).getAllByText(label).length).toBeGreaterThan(0);
+    }
+    const budgetCells = screen.getAllByRole('cell', { name: /%$/ });
+    expect(budgetCells.length).toBeGreaterThan(0);
+  });
+
+  it('expands a channel row to show the flighting table', () => {
+    render(<ChannelTable plan={plan} readOnly />);
+    const rows = screen.getAllByRole('row');
+    const tvRow = rows.find((row) => within(row).queryByText('TV'));
+    expect(tvRow).toBeDefined();
+    const expandButton = within(tvRow as HTMLElement).getByRole('button', { name: /flightings/i });
+    fireEvent.click(expandButton);
+    expect(screen.getByRole('columnheader', { name: /vendor \/ platform/i })).toBeInTheDocument();
+    expect(screen.getByText(/Totals/i)).toBeInTheDocument();
+  });
+
+  it('only shows the add flighting button within an expanded panel', () => {
+    render(<ChannelTable plan={plan} readOnly />);
+    expect(screen.queryByRole('button', { name: /add flighting/i })).not.toBeInTheDocument();
+
+    const firstSummaryRow = screen
+      .getAllByRole('row')
+      .find((row) => within(row).queryByRole('button', { name: /view flightings/i }));
+    expect(firstSummaryRow).toBeDefined();
+    fireEvent.click(within(firstSummaryRow as HTMLElement).getByRole('button', { name: /view flightings/i }));
+
+    const addButtons = screen.getAllByRole('button', { name: /add flighting/i });
+    expect(addButtons).toHaveLength(1);
+  });
+
+  it('keeps the add flighting button visible when a channel has no flightings', () => {
+    const singleChannelPlan = buildSingleChannelPlan('TV');
+    render(<ChannelTable plan={singleChannelPlan} readOnly={false} />);
+
+    const tvRow = screen
+      .getAllByRole('row')
+      .find((row) => within(row).queryByText('TV')) as HTMLElement;
+    fireEvent.click(within(tvRow).getByRole('button', { name: /view flightings/i }));
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete' });
+    fireEvent.click(deleteButton);
+
+    const addButton = screen.getByRole('button', { name: /add flighting/i });
+    expect(addButton).toBeInTheDocument();
+    expect(addButton).not.toHaveAttribute('disabled');
+    expect(screen.queryByRole('button', { name: /view details/i })).not.toBeInTheDocument();
+  });
+
+  // Additional interaction coverage lives in channelTable.lib.test.ts for calculated values.
+});

--- a/src/tests/MediaPlanOverviewCard.test.tsx
+++ b/src/tests/MediaPlanOverviewCard.test.tsx
@@ -1,0 +1,29 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { MediaPlanOverviewCard } from '@/components/MediaPlanOverviewCard';
+import { plans } from '@/data/seed';
+
+const plan = plans[0];
+
+describe('MediaPlanOverviewCard', () => {
+  it('shows core metadata for the media plan', () => {
+    render(<MediaPlanOverviewCard plan={plan} />);
+
+    expect(screen.getByRole('heading', { name: plan.meta.name })).toBeInTheDocument();
+    expect(screen.getByText(/Client:\s*Aurora Beverages/i)).toBeInTheDocument();
+    expect(screen.getByText(plan.meta.code)).toBeInTheDocument();
+    expect(screen.getByText(plan.owner)).toBeInTheDocument();
+    expect(screen.getByText(/Total cost/i)).toBeInTheDocument();
+  });
+
+  it('surfaces the edit action when provided', () => {
+    const onEdit = vi.fn();
+    render(<MediaPlanOverviewCard plan={plan} onEdit={onEdit} />);
+
+    const button = screen.getByRole('button', { name: /edit plan/i });
+    fireEvent.click(button);
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tests/blockPlan.lib.test.ts
+++ b/src/tests/blockPlan.lib.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { plans } from '@/data/seed';
+import {
+  changePlanWeekStart,
+  ensurePlanBlockPlans,
+  syncBlockPlanToFlight,
+  toggleBlockPlanWeek,
+} from '@/lib/blockPlan';
+
+function clonePlan() {
+  return ensurePlanBlockPlans(plans[0]);
+}
+
+describe('block plan helpers', () => {
+  it('generates block plan weeks from flight dates', () => {
+    const plan = clonePlan();
+    const lineItem = plan.lineItems[0];
+    const synced = syncBlockPlanToFlight(plan, lineItem.line_item_id);
+    const refreshed = synced.lineItems.find((item) => item.line_item_id === lineItem.line_item_id);
+    expect(refreshed?.block_plan?.weeks.length).toBeGreaterThan(0);
+    expect(refreshed?.block_plan?.weeks.some((week) => week.active)).toBe(true);
+  });
+
+  it('updates flight boundaries when toggling weeks', () => {
+    const base = clonePlan();
+    const lineItem = base.lineItems[0];
+    const ensured = syncBlockPlanToFlight(base, lineItem.line_item_id);
+    const refreshed = ensured.lineItems.find((item) => item.line_item_id === lineItem.line_item_id);
+    const activeWeeks = refreshed?.block_plan?.weeks.filter((week) => week.active) ?? [];
+    expect(activeWeeks.length).toBeGreaterThan(1);
+    const firstWeek = activeWeeks[0];
+    const toggled = toggleBlockPlanWeek(ensured, lineItem.line_item_id, firstWeek.week_start);
+    const updatedLineItem = toggled.lineItems.find((item) => item.line_item_id === lineItem.line_item_id);
+    const updatedFlight = toggled.flights.find((flight) => flight.flight_id === updatedLineItem?.flight_id);
+    expect(updatedLineItem?.block_plan?.weeks.some((week) => week.active)).toBe(true);
+    expect(updatedFlight?.start_date).not.toBe(firstWeek.week_start);
+    expect(new Date(toggled.end_date)).toBeInstanceOf(Date);
+  });
+
+  it('realigns pulses when week start changes', () => {
+    const base = clonePlan();
+    const ensured = syncBlockPlanToFlight(base, base.lineItems[0].line_item_id);
+    const switched = changePlanWeekStart(ensured, 'Sunday');
+    expect(switched.week_start_day).toBe('Sunday');
+    const sampleLine = switched.lineItems[0];
+    expect(sampleLine.block_plan?.weeks.length).toBeGreaterThan(0);
+  });
+});

--- a/src/tests/channelTable.lib.test.ts
+++ b/src/tests/channelTable.lib.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { plans } from '@/data/seed';
+import {
+  buildFlightingContexts,
+  computeChannelSummaries,
+  setFieldValue,
+  validateField,
+  getFieldValue,
+} from '@/lib/channelTable';
+import type { Channel } from '@/lib/schemas';
+
+const plan = plans[0];
+
+describe('channel table helpers', () => {
+  it('computes channel rollups and budget share', () => {
+    const summaries = computeChannelSummaries(plan);
+    const tvSummary = summaries.find((summary) => summary.channel === 'TV');
+    expect(tvSummary).toBeDefined();
+    expect(tvSummary?.totalPlannedCost).toBeGreaterThan(0);
+    expect(tvSummary?.budgetPercent).toBeCloseTo(
+      (tvSummary?.totalPlannedCost ?? 0) / plan.goal.budget,
+      5,
+    );
+  });
+
+  it('sorts flight contexts by start date', () => {
+    const contexts = buildFlightingContexts(plan, plan.lineItems[0].channel);
+    const dates = contexts
+      .map((context) => context.flight?.start_date)
+      .filter((value): value is string => Boolean(value));
+    const sorted = [...dates].sort();
+    expect(dates).toEqual(sorted);
+  });
+
+  it('validates required fields before committing updates', () => {
+    const channel: Channel = plan.lineItems[0].channel;
+    const context = buildFlightingContexts(plan, channel)[0];
+    const issue = validateField(channel, context, 'start_date', '');
+    expect(issue).not.toBeNull();
+    const result = setFieldValue(channel, context, 'planned_cost', 9999);
+    const updatedValue = getFieldValue(channel, {
+      plan: result.plan,
+      lineItem: result.lineItem,
+      flight: result.flight,
+      vendor: result.vendor,
+      audience: result.audience,
+    }, 'planned_cost');
+    expect(updatedValue).toBe(9999);
+  });
+});

--- a/src/ui/Modal.tsx
+++ b/src/ui/Modal.tsx
@@ -1,6 +1,15 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useId, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { Button } from './Button';
+
+const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
 
 export function Modal({
   title,
@@ -17,17 +26,83 @@ export function Modal({
   children: ReactNode;
   footer?: ReactNode;
 }) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+  const titleId = useId();
+  const descriptionId = description ? `${titleId}-description` : undefined;
+
+  useEffect(() => {
+    if (!open) return;
+
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+    const node = containerRef.current;
+    if (node) {
+      const focusable = node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
+      (focusable[0] ?? node).focus();
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+
+      if (event.key === 'Tab') {
+        const focusable = containerRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
+        if (!focusable || focusable.length === 0) {
+          event.preventDefault();
+          return;
+        }
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        const active = document.activeElement as HTMLElement | null;
+
+        if (event.shiftKey) {
+          if (active === first || !active) {
+            event.preventDefault();
+            last.focus();
+          }
+        } else if (active === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      previouslyFocused.current?.focus?.();
+    };
+  }, [open, onClose]);
+
   if (!open) return null;
 
   return createPortal(
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 p-4">
-      <div className="w-full max-w-2xl rounded-lg bg-white shadow-xl">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 p-4" role="presentation">
+      <div
+        ref={containerRef}
+        className="w-full max-w-2xl rounded-lg bg-white shadow-xl focus:outline-none"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        tabIndex={-1}
+      >
         <header className="flex items-start justify-between border-b border-slate-200 px-6 py-4">
           <div>
-            <h2 className="text-lg font-semibold">{title}</h2>
-            {description ? <p className="text-sm text-slate-500">{description}</p> : null}
+            <h2 id={titleId} className="text-lg font-semibold">
+              {title}
+            </h2>
+            {description ? (
+              <p id={descriptionId} className="text-sm text-slate-500">
+                {description}
+              </p>
+            ) : null}
           </div>
-          <Button variant="ghost" onClick={onClose} aria-label="Close">
+          <Button variant="ghost" onClick={onClose} aria-label="Close dialog">
             ×
           </Button>
         </header>

--- a/src/ui/Table.tsx
+++ b/src/ui/Table.tsx
@@ -1,34 +1,80 @@
-import { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import clsx from 'clsx';
 
 export function Table({ children, className }: { children: ReactNode; className?: string }) {
   return (
-    <div className={clsx('overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm', className)}>
+    <div
+      className={clsx(
+        'overflow-x-auto overflow-y-auto rounded-lg border border-slate-200 bg-white shadow-sm',
+        className,
+      )}
+    >
       <table className="min-w-full divide-y divide-slate-200 text-left text-sm text-slate-700">{children}</table>
     </div>
   );
 }
 
-export function THead({ children }: { children: ReactNode }) {
-  return <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-500">{children}</thead>;
+export function THead({ children, sticky = false }: { children: ReactNode; sticky?: boolean }) {
+  return (
+    <thead
+      className={clsx('bg-slate-50 text-xs uppercase tracking-wide text-slate-500', {
+        'sticky top-0 z-10': sticky,
+      })}
+    >
+      {children}
+    </thead>
+  );
 }
 
 export function TBody({ children }: { children: ReactNode }) {
   return <tbody className="divide-y divide-slate-200 bg-white">{children}</tbody>;
 }
 
-export function Th({ children }: { children: ReactNode }) {
-  return <th className="px-4 py-2 font-medium">{children}</th>;
+export function Th({
+  children,
+  ariaSort,
+  className,
+  style,
+}: {
+  children: ReactNode;
+  ariaSort?: 'none' | 'ascending' | 'descending';
+  className?: string;
+  style?: CSSProperties;
+}) {
+  return (
+    <th
+      className={clsx('px-4 py-2 font-medium', className)}
+      aria-sort={ariaSort ?? undefined}
+      scope="col"
+      style={style}
+    >
+      {children}
+    </th>
+  );
 }
 
-export function Td({ children, align }: { children: ReactNode; align?: 'right' | 'left' | 'center' }) {
+export function Td({
+  children,
+  align,
+  colSpan,
+  className,
+  style,
+}: {
+  children: ReactNode;
+  align?: 'right' | 'left' | 'center';
+  colSpan?: number;
+  className?: string;
+  style?: CSSProperties;
+}) {
   return (
     <td
-      className={clsx('px-4 py-2', {
+      colSpan={colSpan}
+      className={clsx('px-4 py-2', className, {
         'text-right': align === 'right',
         'text-center': align === 'center',
         'text-left': align === 'left',
       })}
+      style={style}
     >
       {children}
     </td>


### PR DESCRIPTION
## Summary
- add plan-level scheduling metadata and block plan helpers to generate, toggle, and realign weekly pulses while keeping timelines in sync
- introduce a dedicated block plan page with weekly toggle controls and hook the media planning view into it with updated overview formatting
- refresh builders, channel edits, seed data, and store adapters so line items maintain block plans and new helpers are covered by unit tests

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d79e0ab040832192d86a4c3733e705